### PR TITLE
Turn nsxmanager_spec into dict

### DIFF
--- a/library/nsx_cluster_prep.py
+++ b/library/nsx_cluster_prep.py
@@ -56,7 +56,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             state=dict(default='present', choices=['present', 'absent']),
-            nsxmanager_spec=dict(required=True, no_log=True),
+            nsxmanager_spec=dict(required=True, no_log=True, type='dict'),
             cluster_moid=dict(required=True)
         ),
         supports_check_mode=False

--- a/library/nsx_controllers.py
+++ b/library/nsx_controllers.py
@@ -97,7 +97,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             state=dict(default='present', choices=['present', 'absent']),
-            nsxmanager_spec=dict(required=True, no_log=True),
+            nsxmanager_spec=dict(required=True, no_log=True, type='dict'),
             deploytype=dict(default='full', choices=['single', 'full', 'lab']),
             deploysize=dict(default='small', choices=['small', 'medium', 'large']),
             syslog_server=dict(),

--- a/library/nsx_ippool.py
+++ b/library/nsx_ippool.py
@@ -56,7 +56,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             state=dict(default='present', choices=['present', 'absent']),
-            nsxmanager_spec=dict(required=True, no_log=True),
+            nsxmanager_spec=dict(required=True, no_log=True, type='dict'),
             name=dict(required=True),
             start_ip=dict(required=True),
             end_ip=dict(required=True),

--- a/library/nsx_logical_switch.py
+++ b/library/nsx_logical_switch.py
@@ -66,7 +66,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             state=dict(default='present', choices=['present', 'absent']),
-            nsxmanager_spec=dict(required=True, no_log=True),
+            nsxmanager_spec=dict(required=True, no_log=True, type='dict'),
             name=dict(required=True),
             description=dict(),
             transportzone=dict(required=True),

--- a/library/nsx_macset.py
+++ b/library/nsx_macset.py
@@ -49,7 +49,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             state=dict(default='present', choices=['present', 'absent']),
-            nsxmanager_spec=dict(required=True, no_log=True),
+            nsxmanager_spec=dict(required=True, no_log=True, type='dict'),
             name=dict(required=True),
             transportzone=dict(required=True),
             description=dict(),

--- a/library/nsx_segment_id_pool.py
+++ b/library/nsx_segment_id_pool.py
@@ -73,7 +73,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             state=dict(default='present', choices=['present', 'absent']),
-            nsxmanager_spec=dict(required=True, no_log=True),
+            nsxmanager_spec=dict(required=True, no_log=True, type='dict'),
             idpoolstart=dict(default=5000),
             idpoolend=dict(default=15000),
             mcast_enabled=dict(type='bool', default=False),

--- a/library/nsx_sso_registration.py
+++ b/library/nsx_sso_registration.py
@@ -42,7 +42,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             state=dict(default='present', choices=['present', 'absent']),
-            nsxmanager_spec=dict(required=True, no_log=True),
+            nsxmanager_spec=dict(required=True, no_log=True, type='dict'),
             sso_lookupservice_url=dict(required=True),
             sso_lookupservice_port=dict(required=True),
             sso_lookupservice_server=dict(required=True),

--- a/library/nsx_transportzone.py
+++ b/library/nsx_transportzone.py
@@ -148,7 +148,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             state=dict(default='present', choices=['present', 'absent']),
-            nsxmanager_spec=dict(required=True, no_log=True),
+            nsxmanager_spec=dict(required=True, no_log=True, type='dict'),
             name=dict(required=True, type='str'),
             description=dict(type='str'),
             controlplanemode=dict(default='UNICAST_MODE',

--- a/library/nsx_vc_registration.py
+++ b/library/nsx_vc_registration.py
@@ -30,7 +30,7 @@ def change_vc_config(session, body_dict):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            nsxmanager_spec=dict(required=True, no_log=True),
+            nsxmanager_spec=dict(required=True, no_log=True, type='dict'),
             vcenter=dict(required=True),
             vcusername=dict(required=True),
             vcpassword=dict(required=True, no_log=True),

--- a/library/nsx_vxlan_prep.py
+++ b/library/nsx_vxlan_prep.py
@@ -87,7 +87,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             state=dict(default='present', choices=['present', 'absent']),
-            nsxmanager_spec=dict(required=True, no_log=True),
+            nsxmanager_spec=dict(required=True, no_log=True, type='dict'),
             cluster_moid=dict(required=True),
             dvs_moid=dict(required=True),
             ippool_id=dict(),


### PR DESCRIPTION
By default `AnsibleModule` treats params as strings, but `nsxmanager_spec` is used as dict. These changes convert `module.params['nsxmanager_spec']` to dict explicit.
