### PR TITLE
Add library to attach a VM to a logical switch

### DIFF
--- a/library/nsx_attach_vm_switch.py
+++ b/library/nsx_attach_vm_switch.py
@@ -48,8 +48,8 @@ def main():
     portgroup_id = module.params['portgroup_id']
     logicalswitch = module.params['logicalswitch']
     
-    if portgroup_id != None and logicalswitch != None:
-      module.fail_json(msg='Only et portgroup_id OR logicalswitch, not both!')
+    if portgroup_id and logicalswitch:
+      module.fail_json(msg='Only set portgroup_id OR logicalswitch, not both!')
 
     from nsxramlclient.client import NsxClient
     client_session = NsxClient(module.params['nsxmanager_spec']['raml_file'], module.params['nsxmanager_spec']['host'],
@@ -62,7 +62,7 @@ def main():
     changed=False
 
     if module.params['state'] == 'absent':
-      if portgroup_id != None:
+      if portgroup_id:
        module.fail_json(msg='If VM must be detached, don\'t set portgroup or logicalswitch') 
     
     action = attachVmToPortgroup(client_session, module.params['objectUUID'],  portgroup_id)

--- a/library/nsx_attach_vm_switch.py
+++ b/library/nsx_attach_vm_switch.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# coding=utf-8
+#
+# Copyright © 2015 VMware, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions
+# of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+# TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+def get_logical_switch(client_session, logical_switch_name):
+    """
+    :param client_session: An instance of an NsxClient Session
+    :param logical_switch_name: The name of the logical switch searched
+    :return: A tuple, with the first item being the logical switch id as string of the first Scope found with the
+             right name and the second item being a dictionary of the logical parameters as return by the NSX API
+    """
+    all_lswitches = client_session.read_all_pages('logicalSwitchesGlobal', 'read')
+    try:
+        logical_switch_params = [scope for scope in all_lswitches if scope['name'] == logical_switch_name][0]
+        logical_switch_id = logical_switch_params['objectId']
+    except IndexError:
+        return None
+
+    return logical_switch_id
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            state=dict(default='present', choices=['present', 'absent']),
+            nsxmanager_spec=dict(required=True, no_log=True, type='dict'),
+            portgroup_id=dict(default=None),
+            logicalswitch=dict(default=None),
+            objectUUID=dict(required=True),
+        ),
+        supports_check_mode=False
+    )
+
+    portgroup_id = module.params['portgroup_id']
+    logicalswitch = module.params['logicalswitch']
+    
+    if portgroup_id != None and logicalswitch != None:
+      module.fail_json(msg='Only et portgroup_id OR logicalswitch, not both!')
+
+    from nsxramlclient.client import NsxClient
+    client_session = NsxClient(module.params['nsxmanager_spec']['raml_file'], module.params['nsxmanager_spec']['host'],
+                             module.params['nsxmanager_spec']['user'], module.params['nsxmanager_spec']['password'])
+
+    if logicalswitch != None:
+      lswitch_id = get_logical_switch(client_session, logicalswitch)
+      portgroup_id = lswitch_id
+
+    changed=False
+
+    if module.params['state'] == 'absent':
+      if portgroup_id != None:
+       module.fail_json(msg='If VM must be detached, don\'t set portgroup or logicalswitch') 
+    
+    action = attachVmToPortgroup(client_session, module.params['objectUUID'],  portgroup_id)
+
+    if action:
+      changed=True
+    module.exit_json(changed=changed)
+
+def attachVmToPortgroup(client_session, objectUUID, portgroup_id):
+  attach = { 'com.vmware.vshield.vsm.inventory.dto.VnicDto': { 'objectId': objectUUID + '.000', 'vnicUuid': objectUUID + '.000', 'portgroupId': portgroup_id } }
+  return client_session.create('logicalSwitchVmAttach', request_body_dict=attach)
+
+from ansible.module_utils.basic import *
+if __name__ == '__main__':
+    main()

--- a/library/nsx_attach_vm_switch.py
+++ b/library/nsx_attach_vm_switch.py
@@ -72,7 +72,11 @@ def main():
     module.exit_json(changed=changed)
 
 def attachVmToPortgroup(client_session, objectUUID, portgroup_id):
-  attach = { 'com.vmware.vshield.vsm.inventory.dto.VnicDto': { 'objectId': objectUUID + '.000', 'vnicUuid': objectUUID + '.000', 'portgroupId': portgroup_id } }
+  attach = { 'com.vmware.vshield.vsm.inventory.dto.VnicDto': 
+      { 
+        'objectId': objectUUID + '.000', 'vnicUuid': objectUUID + '.000', 
+        'portgroupId': portgroup_id } 
+    }
   return client_session.create('logicalSwitchVmAttach', request_body_dict=attach)
 
 from ansible.module_utils.basic import *

--- a/library/nsx_attach_vm_switch.py
+++ b/library/nsx_attach_vm_switch.py
@@ -33,6 +33,14 @@ def get_logical_switch(client_session, logical_switch_name):
 
     return logical_switch_id
 
+def attach_vm_to_portgroup(client_session, object_moid, portgroup_id):
+  attach = { 'com.vmware.vshield.vsm.inventory.dto.VnicDto':
+      {
+        'objectId': object_moid + '.000', 'vnicUuid': object_moid + '.000',
+        'portgroupId': portgroup_id }
+    }
+  return client_session.create('logicalSwitchVmAttach', request_body_dict=attach)
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(
@@ -40,7 +48,7 @@ def main():
             nsxmanager_spec=dict(required=True, no_log=True, type='dict'),
             portgroup_id=dict(default=None),
             logicalswitch=dict(default=None),
-            objectUUID=dict(required=True),
+            object_moid=dict(required=True),
         ),
         supports_check_mode=False
     )
@@ -65,19 +73,11 @@ def main():
       if portgroup_id:
        module.fail_json(msg='If VM must be detached, don\'t set portgroup or logicalswitch') 
     
-    action = attachVmToPortgroup(client_session, module.params['objectUUID'],  portgroup_id)
+    action = attach_vm_to_portgroup(client_session, module.params['object_moid'],  portgroup_id)
 
     if action:
       changed=True
     module.exit_json(changed=changed)
-
-def attachVmToPortgroup(client_session, objectUUID, portgroup_id):
-  attach = { 'com.vmware.vshield.vsm.inventory.dto.VnicDto': 
-      { 
-        'objectId': objectUUID + '.000', 'vnicUuid': objectUUID + '.000', 
-        'portgroupId': portgroup_id } 
-    }
-  return client_session.create('logicalSwitchVmAttach', request_body_dict=attach)
 
 from ansible.module_utils.basic import *
 if __name__ == '__main__':

--- a/library/vcenter_gather_moids.py
+++ b/library/vcenter_gather_moids.py
@@ -30,7 +30,8 @@ VIM_TYPES = {'datacenter': [vim.Datacenter],
              'dvs_name': [vim.dvs.VmwareDistributedVirtualSwitch],
              'datastore_name': [vim.Datastore],
              'resourcepool_name': [vim.ResourcePool],
-             'portgroup_name': [vim.dvs.DistributedVirtualPortgroup]}
+             'portgroup_name': [vim.dvs.DistributedVirtualPortgroup],
+             'virtualmachine_name': [vim.VirtualMachine]}
 
 
 def get_mo(content, searchedname, vim_type_list):
@@ -52,14 +53,15 @@ def main():
             resourcepool_name=dict(type='str'),
             dvs_name=dict(type='str'),
             portgroup_name=dict(type='str'),
-            datastore_name=dict(type='str')
+            datastore_name=dict(type='str'),
+            virtualmachine_name=dict(type='str')
         )
     )
 
     module = AnsibleModule(
         argument_spec=argument_spec,
-        required_one_of=[['cluster_name', 'portgroup_name', 'resourcepool_name', 'dvs_name', 'datastore_name']],
-        mutually_exclusive=[['cluster_name', 'portgroup_name', 'resourcepool_name', 'dvs_name', 'datastore_name']],
+        required_one_of=[['cluster_name', 'portgroup_name', 'resourcepool_name', 'dvs_name', 'datastore_name', 'virtualmachine_name']],
+        mutually_exclusive=[['cluster_name', 'portgroup_name', 'resourcepool_name', 'dvs_name', 'datastore_name', 'virtualmachine_name']],
         supports_check_mode=False
     )
 
@@ -68,7 +70,7 @@ def main():
 
     content = connect_to_api(module)
 
-    searched_parameters = ['cluster_name', 'portgroup_name', 'resourcepool_name', 'dvs_name', 'datastore_name']
+    searched_parameters = ['cluster_name', 'portgroup_name', 'resourcepool_name', 'dvs_name', 'datastore_name', 'virtualmachine_name']
 
     datacenter_mo = find_datacenter_by_name(content, module.params['datacenter_name'])
     datacenter_moid =  datacenter_mo._moId
@@ -78,6 +80,9 @@ def main():
             object_mo = find_cluster_by_name_datacenter(datacenter_mo, module.params[searched_parameter])
         elif searched_parameter == 'portgroup_name' and module.params[searched_parameter]:
             object_mo = get_mo(content, module.params[searched_parameter], VIM_TYPES[searched_parameter])
+        elif searched_parameter == 'virtualmachine_name' and module.params[searched_parameter]:
+            object_mo = get_mo(content, module.params[searched_parameter], VIM_TYPES[searched_parameter])
+            module.exit_json(changed=False, object_uuid=object_mo.config.instanceUuid)
         elif searched_parameter and module.params[searched_parameter]:
             object_mo = get_mo(content, module.params[searched_parameter], VIM_TYPES[searched_parameter])
 


### PR DESCRIPTION
I've build a library to add a VM to a virtualswitch. The input that the library need is portgroup_id or logicalswitch-name with the UUID of the VM.