### PR TITLE
Module for nsx_edge_firewall and nsx_loadbalancer

### DIFF
--- a/library/nsx_edge_firewall.py
+++ b/library/nsx_edge_firewall.py
@@ -1,0 +1,737 @@
+#!/usr/bin/python
+# coding=utf-8
+#
+# Copyright � 2016 VMware, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions
+# of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+# TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+
+DOCUMENTATION = '''
+---
+
+module: nsx_edge_firewall
+
+short_description: Configure edge firewall rules
+
+description:
+  - The M(nsx_edge_firewall) module is used to configure an NSX edge firewall (ESG or DLR). (Not to be confused with the distributed firewall). The module can be used to create, append, query and delete firewall rules. Along with that the default firewall policy can also be set using this. 
+
+options:
+
+  nsxmanager_spec:
+    description:
+      - A dictionary accepting the parameters required to connect to the NSX manager
+    required: true
+    default: null
+    aliases: []
+
+  edge_name:
+    description:
+      - The name of the edge where the firewall will be configured. This parameter is not required if edge_id is given.
+    required: true
+    default: null
+    aliases: []
+
+  edge_id:
+    description:
+      - The ID of the edge where the firewall will be configured. This parameter is not required if edge_name is given.
+    required: true
+    default: null
+    aliases: []
+
+  mode:
+    description:
+      - Specifies the mode of operation. 
+    required: true
+    default: null
+    aliases: []
+    choices: ["create", "append", "query", "delete", "set_default_action" , "reset", "generate_ruleset"]
+
+  source:
+    description:
+      - The source dictionary containing multiple ip addresses, vnic group objects or ipsets. The ipAddress field can be specified as a list or space separated string
+    required: false
+    default: null
+    aliases: []
+
+  destination:
+    description:
+      - The destination dictionary containing multiple ip addresses, vnic group objects or ipsets. The ipAddress field can be specified as a list or space separated string
+    required: false
+    default: null
+    aliases: []
+
+  action:
+    description:
+      - The action to be taken if the rule gets matched
+    required: true
+    default: null
+    aliases: []
+    choices: ["accept", "deny", "reject"]
+
+  name:
+    description:
+      - The name of the rule
+    required: false
+    default: null
+    aliases: []
+
+  description:
+    description:
+      - The description for the rule
+    required: false
+    default: null
+    aliases: []
+
+  application:
+    description:
+      - The application dictionary containing the application ID. This can also contain multiple 'service' blocks containing the 'protocol', 'sourcePort' and 'port' entities. The 'sourcePort' and 'port' fields can be specified as a list or as a space separated string
+    required: false
+    default: null
+    aliases: []
+
+
+  rule_id:
+    description:
+      - The rule ID to be used while deleting a given rule. Only required for the 'delete' mode
+    required: false
+    default: null
+    aliases: []
+
+  direction:
+    description:
+      - The direction of traffic to be considered while filtering
+    choices: [ "in", "out"]
+    default: "any"
+    required: false
+    default: null
+    aliases: []
+
+  rules:
+    description:
+      - The list of rules to be given while using the 'create' mode. These specified rules will overwrite any existing rules for the given edge. The rules follow the same structure as specified in the API.
+    required: false
+    default: null
+    type: list
+    aliases: []
+
+  global_config:
+    description:
+      - The global configuration settings to be given when the firewall is to be configured using the 'create' mode
+    required: false
+    default: null
+    type: dict
+    aliases: []
+
+  yaml_output_file:
+    description:
+      - Only required when the 'generate_ruleset' mode is used. This specifies the YAML file to which the generated rulesets will be written to 
+    required: false
+    default: null    
+    aliases: []
+
+  default_action:
+    description:
+      - The default action to be used by the firewall. 
+    required: false
+    default: null
+    aliases: []
+    choices: [ "accept", "deny" , "reject"]
+
+author:
+  - "VMware"  
+
+notes:
+  - The module requires the nsxramlclient python module as well as the NSX RAML specification document. For further details please check out U(https://github.com/vmware/nsxramlclient) and U(https://github.com/vmware/nsxraml)  
+
+'''
+
+EXAMPLES = '''
+
+#The 'create' mode : Adding multiple firewall rules for the given edge device. This will overwrite the existing firewall config.
+#We also modify the default firewall action and some parameters in the global config
+
+- name: Add multiple firewall rules
+      nsx_edge_firewall:
+        nsxmanager_spec: 
+          raml_file: "nsxraml/nsxvapi.raml"
+          host: "nsxmanager.example.com"
+          user: "admin"
+          password: "l0ngPassw0rd!!"
+        mode: "create"
+        edge_name: "wdc04-0-ops-edge"
+        global_config: 
+          tcpPickOngoingConnections: true
+          dropInvalidTraffic: false
+          tcpTimeoutEstablished: 3600
+          enableSynFloodProtection: true
+        default_action: reject
+        rules: 
+          - name: SSH Restrict Interface
+            action: deny
+            destination: 
+                ipAddress: 161.202.154.228 100.100.100.1 100.100.200.1 100.64.192.14 10.98.129.1 10.98.129.10
+            application:
+                service:
+                  - protocol: TCP
+                    port: 20 21 22 
+
+
+#The 'append' mode : Appending a firewall rule to the given edge device
+- name: Append a firewall rule
+      nsx_edge_firewall:
+        nsxmanager_spec: 
+          raml_file: "nsxraml/nsxvapi.raml"
+          host: "nsxmanager.example.com"
+          user: "admin"
+          password: "l0ngPassw0rd!!"
+        mode: append
+        edge_id: "edge-18"
+        description: "Latest rule"
+        name: "My Rule"
+        action: "accept"
+        source: 
+            ipAddress:
+                - 10.98.129.0/24
+                - 10.98.0.0/23
+                - 10.98.130.0/24
+                - 10.98.128.0/24
+        destination:
+            vnicGroupId: vnic-index-0
+
+#The 'query' mode : Querying all the firewall rules for an edge
+- name: Query all the firewall rules for an edge
+      nsx_edge_firewall:
+        nsxmanager_spec: 
+          raml_file: "nsxraml/nsxvapi.raml"
+          host: "nsxmanager.example.com"
+          user: "admin"
+          password: "l0ngPassw0rd!!"
+        edge_id: "edge-8"
+        mode: query
+
+
+#The 'delete' mode : Deleting a firewall rule with the given rule ID
+- name: Delete a firewall rule
+      nsx_edge_firewall:
+        nsxmanager_spec: 
+          raml_file: "nsxraml/nsxvapi.raml"
+          host: "nsxmanager.example.com"
+          user: "admin"
+          password: "l0ngPassw0rd!!"
+        mode: delete
+        edge_id: "edge-8"
+        rule_id: 181110
+
+#The 'set_default_action' mode : Setting the default firewall action for an edge
+- name: Set default firewall action for an edge firewall
+      nsx_edge_firewall:
+        nsxmanager_spec: 
+          raml_file: "nsxraml/nsxvapi.raml"
+          host: "nsxmanager.example.com"
+          user: "admin"
+          password: "l0ngPassw0rd!!"
+        default_action: "accept"
+        edge_name: "wdc04-0-ops-edge"
+        mode: "set_default_action"
+
+#The 'reset' mode : Resetting an existing firewall configuration
+#WARNING : Will remove all existing rules
+- name: Reset the edge firewall
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Reset firewall config
+      nsx_edge_firewall:
+        nsxmanager_spec:
+          raml_file: "nsxraml/nsxvapi.raml"
+          host: "nsxmanager.example.com"
+          user: "admin"
+          password: "l0ngPassw0rd!!"
+        mode: "reset"
+        edge_id: "edge-1"
+
+#The 'generate_ruleset' mode : Generate YAML ruleset of an existing firewall
+- name: Generate rulesets from an existing firewall
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Generate rulesets from an existing firewall 
+      nsx_edge_firewall:
+        nsxmanager_spec:
+          raml_file: "nsxraml/nsxvapi.raml"
+          host: "nsxmanager.example.com""
+          user: "admin"
+          password: "l0ngPassw0rd!!"
+        mode: "generate_ruleset"
+        edge_id: "edge-1"
+        yaml_output_file: "./generated_rules.yml"
+
+'''
+
+
+##Global vars##
+'''Resource body dict'''
+create_api_resource_body = {'firewall': {'defaultPolicy': dict(),
+                                         'enabled': None,
+                                         'firewallRules': {'firewallRule': list() },
+                                         'globalConfig': {
+                                                           'dropInvalidTraffic': None,
+                                                           'icmp6Timeout': None,
+                                                           'icmpTimeout': None,
+                                                           'ipGenericTimeout': None,
+                                                           'logInvalidTraffic': None,
+                                                           'tcpAllowOutOfWindowPackets': None,
+                                                           'tcpPickOngoingConnections': None,
+                                                           'tcpSendResetForClosedVsePorts': None,
+                                                           'tcpTimeoutClose': None,
+                                                           'tcpTimeoutEstablished': None,
+                                                           'tcpTimeoutOpen': None,
+                                                           'udpTimeout': None}
+                                                       } }
+
+append_api_resource_body = {'firewallRules': {'firewallRule': dict() } }
+
+default_action_resource_body = {'firewallDefaultPolicy': dict()}
+
+
+##Classes##
+
+class Firewall(object):
+    """Represents a firewall object. A firewall object is a combination of the global firewall config, multiple 'FirewallRule' objects and the default firewall action""" 
+    def __init__(self, rules, global_config=None, default_action=None):
+        self._rules = self._remove_duplicate(rules)
+        self._global_config = _to_string(global_config)
+        self._default_action = default_action
+       
+
+    def get_resource_body(self):
+        """Fetch the resource body required for configuring the firewall"""
+        resource_body = create_api_resource_body
+        resource_body["firewall"]["defaultPolicy"]["action"] = self._default_action
+        resource_body["firewall"]["globalConfig"] = self._global_config
+
+        for rule in self._rules:
+            resource_body["firewall"]["firewallRules"]["firewallRule"].append(rule.get_rule())
+
+        return resource_body
+
+    @staticmethod
+    def _remove_duplicate(rules):
+        """Removes duplicate firewall rules from the rules which are to be added"""
+        hash_list = []
+        filtered_rules = []
+
+        for rule in rules:
+            rule_hash = hash(rule)
+            if rule_hash in hash_list:
+                continue
+            hash_list.append(rule_hash)
+            filtered_rules.append(rule)
+        return filtered_rules
+
+
+
+class FirewallRule(object):
+    """Represents a single firewall rule."""
+    def __init__(self, rule):
+        self._action = rule.get("action", None)
+        self._name = rule.get("name", None)
+        self._description = rule.get("description", None)
+        self._source = rule.get("source", None)
+        self._destination = rule.get("destination", None)
+        self._application = rule.get("application", None)
+        self._direction = rule.get("direction", None)
+        self._services = self._format_services()
+        self._format_addresses()
+
+    def _format_addresses(self):
+        """Formats the source and destination ipAddress fields to allow space separated inputs"""
+        for field in (self._source, self._destination):
+            if not field:
+                continue
+
+            ip_address = field.get("ipAddress", None)
+            if not ip_address:
+                continue
+
+            if not isinstance(ip_address,list):
+                ip_address = [ip_address]
+
+            field["ipAddress"] = " ".join(ip_address).split()
+
+    
+    def _format_services(self):
+        """Formats the services block by removing duplicate rules. Formatting also adds capability for space separated src/dst port entries. Also adds certain fields (like 'any') if some parameters (like 'port')  are empty. This helps in comparing existing rules with the rule to be added"""
+        if self._application is None:
+            return None
+
+        services = self._application.get("service", None)
+        if services is None:
+            return services
+
+        if isinstance(services, dict):
+            services = [services]
+
+        for service in services:
+            if not service.get("protocol", None):
+                service["protocol"] = "TCP"
+            if not service.get("port", None):
+                service["port"] = "any"
+            if not service.get("sourcePort", None):
+                service["sourcePort"] = "any"
+
+            for field in ("port", "sourcePort"):
+                ports = service[field]
+                if not isinstance(ports, list):
+                    ports = [ports]
+
+                service[field] = " ".join(map(str,ports)).split()  
+
+        self._application["service"] = services
+
+        return services     
+ 
+    
+    
+    def _get_hashable_entity(self, field, dict_keys_to_extract=[], extractor_algorithm=None):  
+        """Given an object, extracts the part which needs to be hashed for comparison. For custom objects"""
+        if extractor_algorithm:
+            return extractor_algorithm(field)
+
+        if isinstance(field, list):
+            return ",".join(sorted(map(str,field)))
+        elif isinstance(field, (str,int,bool)):
+            return str(field)
+        elif isinstance(field, dict):
+            hash_list = []
+            for entity in dict_keys_to_extract:
+                value = field.get(entity, "")
+                hash_list.append(self._get_hashable_entity(value))
+            return "/".join(hash_list)
+        else:
+            return ""
+
+    
+    def _extract_services(self, services):
+        """Custom extractor for services block"""
+        if not services:
+            return ""
+
+        if isinstance(services, dict):
+            services = [services]
+
+        service_hash_list = []
+        for service in sorted(services):
+            service_hash_list.append(self._get_hashable_entity(service, ["protocol", "sourcePort", "port", "icmpType"]))
+                
+        return "/".join(service_hash_list)
+
+
+    def get_rule(self):
+        """Get the rule represented by this object"""
+        return { "name":self._name, "action":self._action, "description":self._description, "direction":self._direction, "source":self._source, "destination":self._destination, "application":self._application }
+
+    def __hash__(self):
+        """Get the hash of the rule represented by this object"""
+        name_hash_string = self._get_hashable_entity(self._name)
+        action_hash_string = self._get_hashable_entity(self._action)
+        description_hash_string = self._get_hashable_entity(self._description)
+
+        source_hash_string = self._get_hashable_entity(self._source, ["ipAddress","vnicGroupId","groupingObjectId"])
+        destination_hash_string = self._get_hashable_entity(self._destination, ["ipAddress","vnicGroupId","groupingObjectId"])
+        application_id_hash_string = self._get_hashable_entity(self._application, ["applicationId"])
+
+        service_hash_string = self._get_hashable_entity(self._services, extractor_algorithm=self._extract_services)
+        direction_hash_string = self._get_hashable_entity(self._direction)
+
+        hash_tuple = (name_hash_string, action_hash_string, description_hash_string, source_hash_string, destination_hash_string, application_id_hash_string, service_hash_string, direction_hash_string)
+
+        return hash(hash_tuple)
+
+    def __str__(self):
+        return str(self.get_rule())
+  
+def _to_string(obj):
+    """Recursively convert primitive objects to strings(as expected by the API)"""
+    if obj is None:
+        return obj
+
+    primitive = (int, float, str, bool)
+    if isinstance(obj, primitive):
+        return str(obj)
+
+    elif isinstance(obj, dict):
+        for k in obj:
+            obj[k] = _to_string(obj[k])
+        return obj
+
+    elif isinstance(obj, (list, tuple)):
+        obj = list(map(_to_string, obj))
+        return obj
+
+    else:
+        raise ValueError("caught unhandled object type: " + str(obj))
+
+ 
+
+def query_firewall_rules(client_session, edge_id):
+    """ Queries the edge for the list of currently existing firewall rules"""
+    resp = client_session.read("nsxEdgeFirewallConfig", uri_parameters={"edgeId": edge_id})
+    return resp["body"]["firewall"]["firewallRules"]["firewallRule"]
+
+
+def get_edge_id(client_session, edge_name):
+    """Returns the edge_id for a given edge_name"""
+    resp = client_session.read("nsxEdges")
+    edges = resp["body"]["pagedEdgeList"]["edgePage"]["edgeSummary"]
+
+    if not isinstance(edges, list):
+        edges = [edges]
+    for edge in edges:
+        if edge["name"] == edge_name:
+            return edge["id"]
+    return None
+
+
+def display_firewall_rules(rules):
+    """ Displays the firewall rules in human readable format when the 'query' mode is used"""
+    print_str = ""
+    for rule in rules:
+        print_str += "-" * 100
+
+        rule_id = rule["id"]
+        rule_name = rule.get("name", "")
+
+        print_str += "\n%-20s %-40s" % ("RULE ID", rule_id)
+        print_str += "\n%-20s %-40s" % ("RULE NAME", rule_name)
+
+        source = rule.get("source", None)
+
+        if source:
+            print_str += "\n%-20s %-40s" % ("SOURCE", source)
+        else:
+            print_str += "\n%-20s %-40s" % ("SOURCE", "ANY")
+
+        destination = rule.get("destination", None)
+        if destination:
+            print_str += "\n%-20s %-40s" % ("DESTINATION", destination)
+        else:
+            print_str += "\n%-20s %-40s" % ("DESTINATION", "ANY")
+
+        application = rule.get("application", None)
+        if application:
+            print_str += "\n%-20s %-40s" % ("APPLICATION", application)
+        else:
+            print_str += "\n%-20s %-40s" % ("APPLICATION", "ANY")
+
+        action = rule["action"]
+        print_str += "\n%-20s %-40s" % ("ACTION", action)
+
+        description = rule.get("description", "")
+        print_str += "\n%-20s %-40s" % ("DESCRIPTION", description)
+
+        print_str += "\n" + "-" * 100
+        print_str += "\n\n"
+
+    return print_str
+
+
+def main():
+    """main function:
+         Accept arguments from Ansible
+         Create an nsxramlclient session
+         Depending on the mode of operation call the specific function
+    """
+    module = AnsibleModule(argument_spec=
+    dict(
+        nsxmanager_spec=dict(required=True, type="dict"),
+        edge_name=dict(required=False),
+        edge_id=dict(required=False),
+        mode=dict(required=True, choices=["create", "append", "query", "delete", "set_default_action", "reset", "generate_ruleset"]),
+        source=dict(required=False, type="dict"),
+        destination=dict(required=False, type="dict"),
+        action=dict(required=False, choices=["accept", "deny", "reject"]),
+        name=dict(required=False),
+        description=dict(required=False),
+        application=dict(required=False, type="dict"),        
+        rule_id=dict(required=False),
+        yaml_output_file=dict(required=False),
+        direction=dict(required=False, choices=["in", "out"]),
+        global_config=dict(required=False, type="dict"),
+        rules=dict(required=False, type="list"),
+        default_action=dict(required=False, choices=["accept", "deny", "reject"]),
+    ), required_one_of=[["edge_name", "edge_id"]])
+
+    try:
+        client_session = NsxClient(module.params['nsxmanager_spec']['raml_file'],
+                                   module.params['nsxmanager_spec']['host'],
+                                   module.params['nsxmanager_spec']['user'],
+                                   module.params['nsxmanager_spec']['password'])
+    except:
+        module.fail_json(msg="Could not connect to the NSX manager")
+
+    
+
+    edge_name = module.params.get("edge_name", None)
+    if not edge_name:
+        edge_id = module.params["edge_id"]
+    else:
+        edge_id = get_edge_id(client_session, edge_name)
+        if not edge_id:
+            module.fail_json(msg="The edge with the name %s does not exist." % (edge_name))
+
+    mode = module.params["mode"]
+    action = module.params.get("action", None)
+    name = module.params.get("name", None)
+    rule_id = module.params.get("rule_id", None)
+    application = module.params.get("application", None)
+    source = module.params.get("source", None)
+    destination = module.params.get("destination", None)
+    description = module.params.get("description", None)
+    direction = module.params.get("direction", None)
+    rules = module.params.get("rules", None)
+    global_config = module.params.get("global_config", None)
+    default_action = module.params.get("default_action", None)
+    yaml_output_file = module.params.get("yaml_output_file", None)
+
+    if mode == "create":
+        #'create' mode:
+        #   1)Create a Firewall object out of the given rules,global_config and default_action
+        #   2)Get the resource body to be sent
+        #   3)Send the resource body to the NSX Manager
+        if not rules:
+            module.fail_json(msg="The parameter 'rules' is required in order to create the firewall rules")
+
+        firewall_rules = []
+        for rule in rules:
+            firewall_rules.append(FirewallRule(rule))
+  
+        F = Firewall(firewall_rules, global_config, default_action)
+        resource_body = F.get_resource_body()
+
+
+        resp = client_session.update("nsxEdgeFirewallConfig", uri_parameters={"edgeId": edge_id},
+                                     request_body_dict=resource_body)
+        if resp["status"] == 204:
+            module.exit_json(changed=True, msg="Successfully created the rules for the edge with ID %s" % (edge_id))
+        else:
+            module.fail_json(msg="The resource could not be created")
+
+
+    elif mode == "append":
+        #'append' mode:
+        #   1)Check if the rule to be added already exists in the firewall
+        #   2)If yes, exit
+        #   3)If no, create the resource body and send the request to the NSX Manager
+
+        if not action:
+            module.fail_json(msg="The 'action' attribute is mandatory while appending a new rule")
+
+
+        rule_to_be_added = FirewallRule({"name":name, "action":action, "description":description, "source":source, "destination":destination, "application":application, "direction":direction})
+
+        current_rules = [FirewallRule(rule) for rule in query_firewall_rules(client_session, edge_id)]
+        current_hashes = [hash(rule) for rule in current_rules]
+        if hash(rule_to_be_added) in current_hashes:
+            module.exit_json(changed=False, msg="The given rule already exists in the firewall")
+
+        resource_body = append_api_resource_body
+        resource_body["firewallRules"]["firewallRule"] = rule_to_be_added.get_rule() 
+
+        resp = client_session.create("firewallRules", uri_parameters={"edgeId": edge_id},
+                                     request_body_dict=resource_body)
+        if resp["status"] == 201:
+            module.exit_json(changed=True, meta={"ruleId": resp["objectId"]})
+        else:
+            module.fail_json(msg="The resource could not be created")
+
+    elif mode == "query":
+        #'query' mode:
+        #   1)Query the rules existing for the given edge
+        #   2)Display the results (requires <result>.split("\n") in Ansible as Ansible does not support printing newlines
+        rules = query_firewall_rules(client_session, edge_id)
+        print_str = display_firewall_rules(rules)
+
+        module.exit_json(changed=False, meta={"output": print_str})
+
+    elif mode == "delete":
+        #'delete' mode:
+        #   - Delete the rule with the given rule_id
+        if not rule_id:
+            module.fail_json(msg="The parameter 'rule_id' is required to delete a given rule")
+        resp = client_session.delete("firewallRule", uri_parameters={"ruleId": rule_id, "edgeId": edge_id})
+        if resp["status"] == 204:
+            module.exit_json(changed=True, msg="Rule with the ID %s successfully deleted" % (rule_id))
+        else:
+            module.fail_json(msg="Could not delete the rule with ID %s. Make sure that the rule exists" % (rule_id))
+
+    elif mode == "set_default_action":
+        #'set_default_action' mode:
+        #   - Sets the default action for the firewall(can be 'accept', 'deny' or 'reject')
+        if not default_action:
+            module.fail_json(msg="The parameter 'default_action' is required to set the default action")
+
+        resource_body = default_action_resource_body
+        resource_body["firewallDefaultPolicy"]["action"] = default_action
+
+        resp = client_session.update("defaultFirewallPolicy", uri_parameters={"edgeId": edge_id},
+                                     request_body_dict=resource_body)
+        if resp["status"] == 204:
+            module.exit_json(changed=True, msg="Successfully updated the firewall config")
+        else:
+            module.fail_json(msg="The resource could not be updated")
+
+    elif mode == "reset":
+        #'reset' mode:
+        #   - Resets the firewall by deleting all the existing rules
+        resp = client_session.delete("nsxEdgeFirewallConfig",  uri_parameters={"edgeId": edge_id})
+        if resp["status"] == 204:
+            module.exit_json(msg="Successfully reset the firewall configuration for the edge with ID %s" %(edge_id), changed=True)
+        else:
+            module.fail_json(msg="Could not reset the firewall rules for the edge with ID %s" %(edge_id))
+
+    elif mode == "generate_ruleset":
+        #'generate_ruleset' mode (Requires pyyaml module)
+        # Given an existing firewall:
+        #   - Queries and gets the existing user defined rule : Rules having 'ruleType' = 'user'
+        #   - Converts the rules into YAML and writes to the specified file
+        #This file can be used in place in the 'vars_files' section in Ansible and the rules can be referred via the {{firewall_rules}} variable
+        if not yaml_output_file:
+            module.fail_json(msg="The parameter 'yaml_output_file' is required to generate the ruleset")
+
+        rules = query_firewall_rules(client_session, edge_id)
+        user_rules = [rule for rule in rules if rule["ruleType"] == "user"]
+
+        if not user_rules:
+            module.exit_json(msg="No user rules found for the given edge")
+
+        with open(yaml_output_file, "w") as fp:
+            to_dump = {"firewall_rules":user_rules}
+            try:
+                fp.write(yaml.dump(to_dump, default_flow_style=False, indent=4))
+            except IOError:
+                module.fail_json(msg="Error writing to the file %s" %(yaml_output_file))
+            else:
+                module.exit_json(msg="Successfully created the ruleset file %s" %(yaml_output_file))
+
+
+
+import yaml
+from ansible.module_utils.basic import *
+from nsxramlclient.client import NsxClient
+
+if __name__ == "__main__":
+    main()

--- a/library/nsx_loadbalancer.py
+++ b/library/nsx_loadbalancer.py
@@ -1,0 +1,309 @@
+#!/usr/bin/python
+# coding=utf-8
+#
+# Copyright � 2016 VMware, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions
+# of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+# TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+
+DOCUMENTATION = '''
+---
+
+module: nsx_loadbalancer
+
+short_description: Configure NSX loadbalancer
+
+description:
+  - The M(nsx_loadbalancer) module is used to configure the NSX loadbalancer. This involves the configuration of global parameters, application profiles, application rules, monitors, server pools and virtual servers. These objects are created in a specific order and tied together to create the full load balancer configuration. 
+
+options:
+
+  nsxmanager_spec:
+    description:
+      - A dictionary accepting the parameters required to connect to the NSX manager
+    required: true
+    default: null
+    aliases: []
+
+  edge_name:
+    description:
+      - The name of the edge where the loadbalancer will be configured. This parameter is not required if edge_id is given.
+    required: true
+    default: null
+    aliases: []
+
+  edge_id:
+    description:
+      - The ID of the edge where the loadbalancer will be configured. This parameter is not required if edge_name is given.
+    required: true
+    default: null
+    aliases: []
+
+  configuration:
+    description:
+      - The loadbalancer configuration to be applied. This will overwrite any existing configuration.
+    required: true
+    default: null
+    aliases: []
+
+author:
+  - "VMware"
+
+notes:
+    - The module requires the nsxramlclient python module as well as the NSX RAML specification document. For further details please check out U(https://github.com/vmware/nsxramlclient) and U(https://github.com/vmware/nsxraml)
+    - All boolean variables to be passed as parameters will have to be quoted as the NSX API can only recognize boolean variables in string format(quoted).   
+'''
+
+                  
+class BaseObject(object):
+    """The parent class for the various loadbalancer objects""" 
+
+    RAML_OBJECT_NAME = None
+    MAPPING = dict()
+    OBJECT_NAME = None
+
+    def __init__(self, config):
+        self._config = config
+        self._request_body_dict = self._get_request_body_dict()
+        self._object_id = self._create_object()
+       
+    def _get_request_body_dict(self):
+        return { self.__class__.OBJECT_NAME:self._config }
+        
+
+    def _create_object(self):
+        resp = client_session.create(self.RAML_OBJECT_NAME, uri_parameters = {"edgeId":edge_id}, request_body_dict = self._request_body_dict)
+        if resp["status"] == 201:
+            object_id = resp["objectId"]
+            object_name = self._config.get("name", None)
+            self.__class__.MAPPING[object_name] = object_id
+            return object_id
+        else:
+            return None
+
+    @staticmethod
+    def _format_config(config, new_entries, to_pop):
+        config.update(new_entries)
+        for item in to_pop:
+            config.pop(item, None)
+        return config
+    
+    
+    def get_id(self):
+        return self._object_id   
+
+    def get_mapping(self):
+        return self.__class__.MAPPING
+    
+    
+
+class ApplicationProfile(BaseObject):
+    """Class representing an application profile"""
+    RAML_OBJECT_NAME = "applicationProfiles"
+    MAPPING = dict()
+    OBJECT_NAME = "applicationProfile"
+
+    def __init__(self, config):
+        BaseObject.__init__(self, config)
+       
+
+class ApplicationRule(BaseObject):
+    """Class representing an application rule"""
+    RAML_OBJECT_NAME = "appRules"
+    OBJECT_NAME = "applicationRule"
+    MAPPING = dict()
+    
+
+    def __init__(self, config):
+        BaseObject.__init__(self, config)
+
+                        
+
+class Monitor(BaseObject):
+    """Class representing a loadbalancer monitor"""
+    RAML_OBJECT_NAME = "lbMonitors"
+    OBJECT_NAME = "monitor"
+    MAPPING = dict()
+    
+    def __init__(self, config):
+        BaseObject.__init__(self, config)
+ 
+
+class Pool(BaseObject):
+    """Class representing the backend server pool"""
+    RAML_OBJECT_NAME = "pools"
+    OBJECT_NAME = "pool"
+    MAPPING = dict()
+    
+    def __init__(self, config):
+        BaseObject.__init__(self, config)
+
+    def _create_object(self):
+        monitor_name = self._config.get("monitorName", None)
+        monitor_name_to_id = Monitor.MAPPING
+        monitor_id = monitor_name_to_id.get(monitor_name, None)
+        self._format_config(self._config, {"monitorId":monitor_id}, ["monitorName"])
+
+        BaseObject._create_object(self)
+        
+        
+
+class VirtualServer(BaseObject):
+    """Class representing a virtual server which binds the frontend with the backend"""
+    RAML_OBJECT_NAME = "virtualServers"
+    OBJECT_NAME = "virtualServer"
+    MAPPING = dict()
+    
+    def __init__(self, config):
+        BaseObject.__init__(self, config)
+
+    def _create_object(self):
+        pool_name = self._config.get("poolName", None)
+        pool_name_to_id = Pool.MAPPING
+        pool_id = pool_name_to_id.get(pool_name, None)
+        
+        application_rule_name = self._config.get("applicationRuleName", None)
+        application_rule_name_to_id = ApplicationRule.MAPPING
+        application_rule_id = application_rule_name_to_id.get(application_rule_name, None)
+        
+        application_profile_name = self._config.get("applicationProfileName", None)
+        application_profile_name_to_id = ApplicationProfile.MAPPING
+        application_profile_id = application_profile_name_to_id.get(application_profile_name, None)
+        
+        
+        self._format_config(self._config, {"applicationRuleId":application_rule_id, "applicationProfileId":application_profile_id, "defaultPoolId":pool_id}, ["poolName", "applicationRuleName", "applicationProfileName"])
+        
+        BaseObject._create_object(self)
+
+
+        
+class LoadBalancer(object):
+    """Class representing the load balancer"""
+
+    RAML_OBJECT_NAME = "loadBalancer"
+    OBJECT_NAME = "loadBalancer"
+    OBJECT_CREATION_ORDER = ["applicationProfile", "applicationRule", "monitor", "pool", "virtualServer"]
+    OBJECT_NAME_TO_CLASS = {"applicationProfile":ApplicationProfile, "applicationRule":ApplicationRule, "monitor":Monitor, "pool":Pool, "virtualServer":VirtualServer}     
+
+
+    def __init__(self, config):
+        self._config = config
+        self._global_config = self._fetch_global_config()
+        self._request_body_dict = {LoadBalancer.OBJECT_NAME:self._global_config}
+
+    def _fetch_global_config(self):
+        enabled = self._config.get("enabled", None)
+        enable_service_insertion = self._config.get("enableServiceInsertion", None)
+        acceleration_enabled = self._config.get("accelerationEnabled", None)
+        logging = self._config.get("logging", None)
+        return {"enabled":enabled, "accelerationEnabled":acceleration_enabled, "enableServiceInsertion":enable_service_insertion, "logging":logging}
+
+    def _enable(self):
+        resp = client_session.update(LoadBalancer.RAML_OBJECT_NAME, uri_parameters = {"edgeId":edge_id}, request_body_dict = self._request_body_dict)
+        if resp["status"] == 204:
+            return True
+        else:
+            return False                
+        
+        
+    def _create_objects(self):
+        for obj in LoadBalancer.OBJECT_CREATION_ORDER:
+            configs = self._config.pop(obj, None)
+            if not configs:
+                continue
+
+            if not isinstance(configs, list):
+                configs = [configs]
+
+            cls = LoadBalancer.OBJECT_NAME_TO_CLASS[obj]
+
+            for config in configs:
+                _ = cls(config)
+
+    def configure(self):
+        status = self._enable()
+        if not status:
+            module.fail_json(msg="Error instantiating the global loadbalancer configuration")
+
+        self._create_objects()
+        module.exit_json(changed=True, msg="Successfully created the load balancer with the given configuration")
+        
+ 
+
+def get_edge_id(client_session, edge_name):
+    """Returns the edge_id for a given edge_name"""
+    resp = client_session.read("nsxEdges")
+    edges = resp["body"]["pagedEdgeList"]["edgePage"]["edgeSummary"]
+
+    if not isinstance(edges, list):
+        edges = [edges]
+    for edge in edges:
+        if edge["name"] == edge_name:
+            return edge["id"]
+    return None
+
+def main():
+    """Main function: 
+        1)Get parameters 
+        2)Get edge id if edge name is given
+        3)Create a LoadBalancer object with the given config
+        4)Configure the loadbalancer
+            a)Enable the load balancer and configure the global params
+            b)Create the objects in the given order:
+                - ApplicationProfile
+                - ApplicationRule
+                - Monitor 
+                - Pool (Fetch the monitorId associated with the monitorName for the monitor(s) created above)
+                - VirtualServer (Fetch the applicationProfileID, applicationRuleId and defaultPoolId from the applicationProfileName, applicationRuleName and poolName params)
+    """
+
+    global edge_id,client_session,module
+
+    module = AnsibleModule(argument_spec=dict(nsxmanager_spec=dict(required=True, type="dict"),
+                                                edge_name=dict(required=False),
+                                                    edge_id=dict(required=False),
+                                                        configuration=dict(required=True, type="dict")
+                                                                    ))
+
+
+    try:
+        client_session = NsxClient(module.params['nsxmanager_spec']['raml_file'],
+                                   module.params['nsxmanager_spec']['host'],
+                                   module.params['nsxmanager_spec']['user'],
+                                   module.params['nsxmanager_spec']['password'])
+    except:
+        module.fail_json(msg="Could not connect to the NSX manager")
+
+    
+
+    edge_name = module.params.get("edge_name", None)
+    if not edge_name:
+        edge_id = module.params["edge_id"]
+    else:
+        edge_id = get_edge_id(client_session, edge_name)
+        if not edge_id:
+            module.fail_json(msg="The edge with the name %s does not exist." % (edge_name))   
+
+    configuration = module.params.get("configuration", None)
+
+    L = LoadBalancer(configuration)
+    L.configure()
+
+from ansible.module_utils.basic import *
+from nsxramlclient.client import NsxClient
+
+if __name__ == "__main__":
+    main()
+    

--- a/loadbalancer_configuration.yml
+++ b/loadbalancer_configuration.yml
@@ -1,0 +1,97 @@
+---
+#0)Define a monitor which checks /favicon.ico on the backend server
+#1)Redirect all HTTP request to HTTPS
+#2)Loadbalance all HTTPS requests coming to the frontend 1.1.1.1 to the backends 172.16.0.8 and 172.16.0.9 port 443
+#3)Loadbalance all requests to 1.1.1.1 port 8080 to 172.16.0.8 and 172.16.0.9 port 8080 
+
+loadBalancer:
+    accelerationEnabled: 'true'
+    enabled: 'true'
+    logging: 
+        logLevel: error
+
+    applicationProfile:
+    -   name: TCP
+        template: TCP
+
+    applicationRule:
+        name: HTTP Redirect
+        script: redirect scheme https code 302 if !{ ssl_fc }
+
+    monitor:
+        expected: HTTP/1.1 200
+        interval: '5'
+        maxRetries: '3'
+        method: GET
+        monitorId: monitor-1
+        name: HTTPS-MONITOR
+        timeout: '5'
+        type: https
+        url: /favicon.ico
+
+    pool:
+    -   algorithm: ip-hash
+        member:
+        -   condition: enabled
+            ipAddress: 172.16.0.8
+            monitorPort: '443'
+            name: BACKEND-1
+            port: '443'
+            weight: '1'
+        -   condition: enabled
+            ipAddress: 172.16.0.9
+            monitorPort: '443'
+            name: BACKEND-2
+            port: '443'
+            weight: '1'
+        monitorName: HTTPS-MONITOR
+        name: HTTPS-POOL
+        transparent: 'true'
+
+    -   algorithm: ip-hash
+        member:
+        -   condition: enabled
+            ipAddress: 172.16.0.8  
+            monitorPort: '443'
+            name: BACKEND-1
+            port: '8080'
+            weight: '1'
+        -   condition: enabled
+            ipAddress: 172.16.0.9
+            monitorPort: '443'
+            name: BACKEND-2
+            port: '8080'
+            weight: '1'
+        monitorName: HTTPS-MONITOR
+        name: PROXY-POOL
+        transparent: 'true'
+
+
+    virtualServer:
+    -   accelerationEnabled: 'false'
+        applicationProfileName: TCP
+        applicationRuleName: HTTP Redirect
+        enabled: 'true'
+        ipAddress: 1.1.1.1
+        name: HTTP-FRONTEND
+        port: '80'
+        protocol: http
+
+    -   accelerationEnabled: 'true'
+        applicationProfileName: TCP
+        poolName: HTTPS-POOL
+        enabled: 'true'
+        ipAddress: 1.1.1.1
+        name: HTTPS-FRONTEND
+        port: '443'
+        protocol: tcp
+
+    -   accelerationEnabled: 'true'
+        applicationProfileName: TCP
+        poolName: PROXY-POOL
+        enabled: 'true'
+        ipAddress: 1.1.1.1
+        name: PROXY-FRONTEND
+        port: '8080'
+        protocol: tcp   
+

--- a/test_edge_firewall.yml
+++ b/test_edge_firewall.yml
@@ -1,0 +1,64 @@
+---
+- name: Testing the firewall related modules
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Add multiple firewall rules
+      nsx_edge_firewall:
+        nsxmanager_spec:
+          raml_file: "nsxraml/nsxvapi.raml"
+          host: "nsxmanager.example.com"
+          user: "admin"
+          password: "l0ngPassw0rd!!"
+        mode: "create"
+        edge_name: "dc-jp-edge-1"
+        global_config: 
+          tcpPickOngoingConnections: true
+          tcpTimeoutEstablished: 500
+          enableSynFloodProtection: false
+          ipGenericTimeout: 12000
+        default_action: deny
+        rules:
+          - name: deny_rule
+            action: deny
+            destination:
+              ipAddress:
+                - 2.2.2.2
+                - 1.1.1.1          
+            source: 
+              ipAddress: 8.8.8.8 9.9.9.9 10.10.10.10/26
+            application:
+              service:
+                - port: 
+                  - 181
+                  - 182
+                  protocol: UDP
+                  sourcePort: 53
+                - port: 15 22
+                  protocol: UDP
+                  sourcePort: 53
+
+          - name: Rule_icmp_reject
+            action: reject
+            destination:
+              ipAddress: 2.2.2.2 1.1.1.1
+            source:
+              ipAddress:
+                - 8.8.8.8
+                - 9.9.9.9
+                - 10.10.10.10/26
+            application:
+              service:
+                - port: 
+                  - 15 
+                  - 22            
+                  protocol: UDP
+                  sourcePort: 53
+                - protocol: ICMP
+                  icmpType: echo-reply
+ 
+
+          
+
+
+        

--- a/test_loadbalancer.yml
+++ b/test_loadbalancer.yml
@@ -1,0 +1,16 @@
+---
+- name: Testing the loadbalancer module
+  hosts: localhost
+  connection: local
+  vars_files:
+    - loadbalancer_configuration.yml
+  tasks:
+    - name: Configure the loadbalancer
+      nsx_loadbalancer:
+        nsxmanager_spec:
+          raml_file: "nsxraml/nsxvapi.raml"
+          host: "nsxmanager.example.com"
+          user: "admin"
+          password: "l0ngPassw0rd!!"        
+        edge_name: "cust-edge"
+        configuration: "{{loadBalancer}}"


### PR DESCRIPTION
**nsx_edge_firewall**

**Summary** : The modules extends nsxansible with the functionality to configure firewall on an NSX edge or DLR

**Details** : 
    Create/Append/Query/Delete/Reset firewall rules and set default action for the given edge firewall. 
   
**Sample workflow** :

- Add multiple rules to an edge firewall , modify the global config and default policy 
- Append a firewall rules 
- Delete a specific rule with a given rule ID (rule ID is generated when a rule is created)
- Change the default firewall action to 'accept','deny' or 'reject'
- Query the existing edge firewall rules
- Reset the firewall configuration by deleting all the rules

(See examples and test playbooks for more details)

**Notes**:

- Duplicate firewall rules are removed while adding multiple firewall rules
- A firewall rule is appended only after verifying that the given rule does not already exist
- Had added the functionality to convert existing configuration of a given firewall to YAML rulesets. It made sense for our use case as we were having problems manually entering a bunch of firewall rules. The converted YAML rulesets can be slightly modified and fed into Ansible for each new customer. 
Haven't added that functionality here as it was a more specific use case and moreover depends on the external 'pyyaml' module. 

**nsx_loadbalancer**

**Summary** : This is a general purpose module for configuring the load-balancer functionality on an NSX edge appliance 

**Details** :  The modules uses multiple APIs to create the various load-balancer objects like Application Profiles, Application Rules, Monitors, Pools and Virtual Servers. 

**Sample Workflow** :
- Create application profiles for TCP and UDP templates 
- Create an application rule to redirect HTTP traffic to HTTPS
- Create an HTTPS monitor to health check the backend servers
- Create pool(s) which maps to the backend servers and refers to the monitor created above(referring to the monitorName)
- Create  virtual server(s) which maps to a frontend IP address and port. The virtual server also maps to the application profile, application rule and pool using their names specified above.

(See examples and test playbooks for more details)

