### PR TITLE
Enhancements to NSX Edge default gateway

### DIFF
--- a/library/nsx_edge_dhcp.py
+++ b/library/nsx_edge_dhcp.py
@@ -84,7 +84,7 @@ def add_dhcp_pool(client_session, edge_name, ip_range, default_gateway, subnet, 
         return False
 
 
-def dhcp_server(client_session, edge_name, dhcp_enabled=None, syslog_enabled=None, syslog_level=None):
+def dhcp_server(client_session, edge_name, dhcp_enabled, syslog_enabled, syslog_level):
     """
     :param client_session: An instance of an NsxClient session
     :param edge_name: The name of the edge searched
@@ -141,7 +141,7 @@ def main():
                 dns_server_1=dict(),
                 dns_server_2=dict(),
                 lease_time=dict(),
-                auto_dns=dict(),
+                auto_dns=dict(default='false'),
                 dhcp_enabled=dict(default='yes', choices=['yes', 'no']),
                 syslog_enabled=dict(default='yes', choices=['yes', 'no']),
                 syslog_level=dict(default='info', choices=['emergency', 'alert', 'critical', 'error', 'warning', 'notice', 'info', 'debug'])
@@ -160,6 +160,8 @@ def main():
 
     if module.params['mode'] == 'create_pool':
         changed =  add_dhcp_pool(client_session, module.params['name'], module.params['ip_range'], module.params['default_gateway'], module.params['subnet'], module.params['domain_name'], module.params['dns_server_1'], module.params['dns_server_2'], module.params['lease_time'], module.params['auto_dns'])
+    elif module.params['mode'] == 'enable_service':
+        changed = dhcp_service(client_session, module.params['name'], module.params['dhcp_enabled'], module.params['syslog_enabled'], module.params['syslog_level'])
     
     if changed:
         module.exit_json(changed=True)

--- a/library/nsx_edge_dhcp.py
+++ b/library/nsx_edge_dhcp.py
@@ -84,6 +84,46 @@ def add_dhcp_pool(client_session, edge_name, ip_range, default_gateway, subnet, 
         return False
 
 
+def dhcp_server(client_session, edge_name, enabled=None, syslog_enabled=None, syslog_level=None):
+    """
+
+    """
+    edge_id, edge_params = get_edge(client_session, edge_name)
+
+    if not edge_id:
+        return None
+
+    change_needed = False
+
+    # Check current DHCP service status
+    current_dhcp_config = client_session.read('dhcp', uri_parameter={'edgeId': edge_id})['body']
+    new_dhcp_config = current_dhcp_config
+
+    if enabled:
+        if current_dhcp_config['dhcp']['enabled'] == 'false':
+            new_dhcp_config['dhcp']['enabled'] = 'true'
+            change_needed = True
+    else:
+        if current_dhcp_config['dhcp']['enabled'] == 'true':
+            new_dhcp_config['dhcp']['enabled'] = 'false'
+            change_needed = True
+
+    if syslog_level:
+        if current_dhcp_config['dhcp']['logging']['logLevel'] != syslog_level:
+            new_dhcp_config['dhcp']['logging']['logLevel'] = syslog_level
+            change_needed = True
+
+    if not change_needed:
+        return True
+    else:
+        result = client_session.update('dhcp', uri_parameter={'edgeId': edge_id}, request_body_dict=new_dhcp_config)
+
+        if cfg_result['status'] == 204:
+            return True
+        else:
+            return False
+
+
 def main():
     module = AnsibleModule(
             argument_spec=dict(

--- a/library/nsx_edge_dhcp.py
+++ b/library/nsx_edge_dhcp.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+# coding=utf-8
+#
+# Copyright © 2015-2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the X11 (MIT) (the “License”) set forth below;
+#
+# you may not use this file except in compliance with the License. Unless required by applicable law or agreed to in
+# writing, software distributed under the License is distributed on an “AS IS” BASIS, without warranties or conditions
+# of any kind, EITHER EXPRESS OR IMPLIED. See the License for the specific language governing permissions and
+# limitations under the License. Permission is hereby granted, free of charge, to any person obtaining a copy of this
+# software and associated documentation files (the "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+# the Software.
+#
+# "THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+# AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.”
+
+# Portions of this code have been copied from the https://github.com/vmware/pynsxv library
+#
+# pynsxv/library/nsx_dhcp.py
+# Adapted for use with Ansible
+
+__author__ = 'virtualelephant'
+
+def get_edge(client_session, edge_name):
+    """
+    :param client session: An instance of an NsxClient Session
+    :param edge_name: The name of the edge searched
+    :return: A tuple, with the first item being the edge or dlr id as string of the first Scope found with the
+             right name and the second item being a dictionary of the logical parameters as return by the NSX API
+    """
+    all_edge = client_session.read_all_pages('nsxEdges', 'read')
+
+    try:
+        edge_params = [scope for scope in all_edge if scope['name'] == edge_name][0]
+        edge_id = edge_params['objectId']
+    except IndexError:
+        return None, None
+
+    return edge_id, edge_params
+
+
+def add_dhcp_pool(client_session, edge_name, ip_range, default_gateway, subnet, domain_name,
+                  dns_server_1, dns_server_2, lease_time, auto_dns=None):
+    """
+    :param client_session: An instance of an NsxClient session
+    :param edge_name: The name of the edge searched
+    :param ip_range: An IP range for the IP pool
+    :param default_gateway: The default gateway for the IP pool
+    :param subnet: The subnet of the IP pool
+    :param domain_name: The DNS domain name
+    :param dns_server_1: The primary DNS for the IP pool
+    :param dns_server_2: The secondary DNS for the IP pool
+    :param lease_time: The DHCP lease time value, default is 1 day
+    :param auto_dns: If set to true, the DNS servers from the NSX Manager will be used
+    :return: Returns true or false
+    """
+    edge_id, edge_params = get_edge(client_session, edge_name)
+
+    if not edge_id:
+        return None
+
+    dhcp_pool_dict = {'ipRange': ip_range,
+                      'defaultGateway': default_gateway,
+                      'subnetMask': subnet,
+                      'domainName': domain_name,
+                      'primaryNameServer': dns_server_1,
+                      'secondaryNameServer': dns_server2,
+                      'leaseTime': lease_time,
+                      'autoConfigureDNS': auto_dns}
+
+    cfg_result = client_session.create('dhcpPool', uri_parameters={'edgeId': edge_id}, request_body_dict={'ipPool': dhcp_pool_dict})
+
+    if cfg_result['status'] == 204:
+        return True
+    else:
+        return False
+
+
+def main():
+    module = AnsibleModule(
+            argument_spec=dict(
+                state=dict(default='present', choices=['present', 'absent']),
+                nsxmanager_spec=dict(required=True, no_log=True, type='dict'),
+                name=dict(required=True),
+                ip_range=dict(required=True),
+                default_gateway=dict(),
+                subnet=dict(required=True),
+                domain_name=dict(),
+                dns_server_1=dict(),
+                dns_server_2=dict(),
+                lease_time=dict(default='86400'),
+                auto_dns=dict(default=False, choices=[True, False])
+            ),
+            supports_check_mode=False
+    )
+
+    from nsxramlclient.client import NsxClient
+    client_session = NsxClient(module.params['nsxmanager_spec']['raml_file'],
+                               module.params['nsxmanager_spec']['host'],
+                               module.params['nsxmanager_spec']['user'],
+                               module.params['nsxmanager_spec']['password'])
+
+    changed = False
+    edge_id, edge_params = get_edge(client_session, module.params['name'])
+    
+    if changed:
+        module.exit_json(changed=True)
+    else:
+        module.exit_json(changed=False)
+
+
+from ansible.module_utils.basic import *
+if __name__ == '__main__':
+    main()

--- a/library/nsx_edge_firewall.py
+++ b/library/nsx_edge_firewall.py
@@ -1,0 +1,689 @@
+#!/usr/bin/python
+# coding=utf-8
+#
+# Copyright � 2016 VMware, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions
+# of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+# TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+# Cloned from https://github.com/sarathk-vmw/nsxansible
+
+
+DOCUMENTATION = '''
+---
+
+module: nsx_edge_firewall
+
+short_description: Configure edge firewall rules
+
+description:
+  - The M(nsx_edge_firewall) module is used to configure an NSX edge firewall (ESG or DLR). (Not to be confused with the distributed firewall). The module can be used to create, append, query, delete and reset firewall rules. Along with that the default firewall policy can also be set using this. 
+
+options:
+
+  nsxmanager_spec:
+    description:
+      - A dictionary accepting the parameters required to connect to the NSX manager
+    required: true
+    default: null
+    aliases: []
+
+  edge_name:
+    description:
+      - The name of the edge where the firewall will be configured. This parameter is not required if edge_id is given.
+    required: true
+    default: null
+    aliases: []
+
+  edge_id:
+    description:
+      - The ID of the edge where the firewall will be configured. This parameter is not required if edge_name is given.
+    required: true
+    default: null
+    aliases: []
+
+  mode:
+    description:
+      - Specifies the mode of operation. 
+    required: true
+    default: null
+    aliases: []
+    choices: ["create", "append", "query", "delete", "set_default_action"]
+
+  source:
+    description:
+      - The source dictionary containing multiple ip addresses, vnic group objects or ipsets. The ipAddress field can be specified as a list or space separated string
+    required: false
+    default: null
+    aliases: []
+
+  destination:
+    description:
+      - The destination dictionary containing multiple ip addresses, vnic group objects or ipsets. The ipAddress field can be specified as a list or space separated string
+    required: false
+    default: null
+    aliases: []
+
+  action:
+    description:
+      - The action to be taken if the rule gets matched
+    required: true
+    default: null
+    aliases: []
+    choices: ["accept", "deny", "reject"]
+
+  name:
+    description:
+      - The name of the rule
+    required: false
+    default: null
+    aliases: []
+
+  description:
+    description:
+      - The description for the rule
+    required: false
+    default: null
+    aliases: []
+
+  application:
+    description:
+      - The application dictionary containing the application ID. This can also contain multiple 'service' blocks containing the 'protocol', 'sourcePort' and 'port' entities. The 'sourcePort' and 'port' fields can be specified as a list or as a space separated string
+    required: false
+    default: null
+    aliases: []
+
+
+  rule_id:
+    description:
+      - The rule ID to be used while deleting a given rule. Only required for the 'delete' mode
+    required: false
+    default: null
+    aliases: []
+
+  direction:
+    description:
+      - The direction of traffic to be considered while filtering
+    choices: [ "in", "out"]
+    default: "any"
+    required: false
+    default: null
+    aliases: []
+
+  rules:
+    description:
+      - The list of rules to be given while using the 'create' mode. These specified rules will overwrite any existing rules for the given edge. The rules follow the same structure as specified in the API.
+    required: false
+    default: null
+    type: list
+    aliases: []
+
+  global_config:
+    description:
+      - The global configuration settings to be given when the firewall is to be configured using the 'create' mode
+    required: false
+    default: null
+    type: dict
+    aliases: []
+
+  default_action:
+    description:
+      - The default action to be used by the firewall. 
+    required: false
+    default: null
+    aliases: []
+    choices: [ "accept", "deny" , "reject"]
+
+author:
+  - "VMware"  
+
+notes:
+  - The module requires the nsxramlclient python module as well as the NSX RAML specification document. For further details please check out U(https://github.com/vmware/nsxramlclient) and U(https://github.com/vmware/nsxraml)  
+
+'''
+
+EXAMPLES = '''
+
+#The 'create' mode : Adding multiple firewall rules for the given edge device. This will overwrite the existing firewall config.
+#We also modify the default firewall action and some parameters in the global config
+
+- name: Add multiple firewall rules
+      nsx_edge_firewall:
+        nsxmanager_spec: 
+          raml_file: "nsxraml/nsxvapi.raml"
+          host: "nsxmanager.example.com"
+          user: "admin"
+          password: "l0ngPassw0rd!!"
+        mode: "create"
+        edge_name: "wdc04-0-ops-edge"
+        global_config: 
+          tcpPickOngoingConnections: true
+          dropInvalidTraffic: false
+          tcpTimeoutEstablished: 3600
+          enableSynFloodProtection: true
+        default_action: reject
+        rules: 
+          - name: SSH Restrict Interface
+            action: deny
+            destination: 
+                ipAddress: 161.202.154.228 100.100.100.1 100.100.200.1 100.64.192.14 10.98.129.1 10.98.129.10
+            application:
+                service:
+                  - protocol: TCP
+                    port: 20 21 22 
+
+
+#The 'append' mode : Appending a firewall rule to the given edge device
+- name: Append a firewall rule
+      nsx_edge_firewall:
+        nsxmanager_spec: 
+          raml_file: "nsxraml/nsxvapi.raml"
+          host: "nsxmanager.example.com"
+          user: "admin"
+          password: "l0ngPassw0rd!!"
+        mode: append
+        edge_id: "edge-18"
+        description: "Latest rule"
+        name: "My Rule"
+        action: "accept"
+        source: 
+            ipAddress:
+                - 10.98.129.0/24
+                - 10.98.0.0/23
+                - 10.98.130.0/24
+                - 10.98.128.0/24
+        destination:
+            vnicGroupId: vnic-index-0
+
+#The 'query' mode : Querying all the firewall rules for an edge
+- name: Query all the firewall rules for an edge
+      nsx_edge_firewall:
+        nsxmanager_spec: 
+          raml_file: "nsxraml/nsxvapi.raml"
+          host: "nsxmanager.example.com"
+          user: "admin"
+          password: "l0ngPassw0rd!!"
+        edge_id: "edge-8"
+        mode: query
+
+
+#The 'delete' mode : Deleting a firewall rule with the given rule ID
+- name: Delete a firewall rule
+      nsx_edge_firewall:
+        nsxmanager_spec: 
+          raml_file: "nsxraml/nsxvapi.raml"
+          host: "nsxmanager.example.com"
+          user: "admin"
+          password: "l0ngPassw0rd!!"
+        mode: delete
+        edge_id: "edge-8"
+        rule_id: 181110
+
+#The 'set_default_action' mode : Setting the default firewall action for an edge
+- name: Set default firewall action for an edge firewall
+      nsx_edge_firewall:
+        nsxmanager_spec: 
+          raml_file: "nsxraml/nsxvapi.raml"
+          host: "nsxmanager.example.com"
+          user: "admin"
+          password: "l0ngPassw0rd!!"
+        default_action: "accept"
+        edge_name: "wdc04-0-ops-edge"
+        mode: "set_default_action"
+
+#The 'reset' mode : Resetting an existing firewall configuration
+#WARNING : Will remove all existing rules
+- name: Reset the edge firewall
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Reset firewall config
+      nsx_edge_firewall:
+        nsxmanager_spec:
+          raml_file: "nsxraml/nsxvapi.raml"
+          host: "nsxmanager.example.com"
+          user: "admin"
+          password: "l0ngPassw0rd!!"
+        mode: "reset"
+        edge_id: "edge-1"
+
+'''
+
+
+##Global vars##
+'''Resource body dict'''
+create_api_resource_body = {'firewall': {'defaultPolicy': dict(),
+                                         'enabled': None,
+                                         'firewallRules': {'firewallRule': list() },
+                                         'globalConfig': {
+                                                           'dropInvalidTraffic': None,
+                                                           'icmp6Timeout': None,
+                                                           'icmpTimeout': None,
+                                                           'ipGenericTimeout': None,
+                                                           'logInvalidTraffic': None,
+                                                           'tcpAllowOutOfWindowPackets': None,
+                                                           'tcpPickOngoingConnections': None,
+                                                           'tcpSendResetForClosedVsePorts': None,
+                                                           'tcpTimeoutClose': None,
+                                                           'tcpTimeoutEstablished': None,
+                                                           'tcpTimeoutOpen': None,
+                                                           'udpTimeout': None}
+                                                       } }
+
+append_api_resource_body = {'firewallRules': {'firewallRule': dict() } }
+
+default_action_resource_body = {'firewallDefaultPolicy': dict()}
+
+
+##Classes##
+
+class Firewall(object):
+    """Represents a firewall object. A firewall object is a combination of the global firewall config, multiple 'FirewallRule' objects and the default firewall action""" 
+    def __init__(self, rules, global_config=None, default_action=None):
+        self._rules = self._remove_duplicate(rules)
+        self._global_config = _to_string(global_config)
+        self._default_action = default_action
+       
+
+    def get_resource_body(self):
+        """Fetch the resource body required for configuring the firewall"""
+        resource_body = create_api_resource_body
+        resource_body["firewall"]["defaultPolicy"]["action"] = self._default_action
+        resource_body["firewall"]["globalConfig"] = self._global_config
+
+        for rule in self._rules:
+            resource_body["firewall"]["firewallRules"]["firewallRule"].append(rule.get_rule())
+
+        return resource_body
+
+    @staticmethod
+    def _remove_duplicate(rules):
+        """Removes duplicate firewall rules from the rules which are to be added"""
+        hash_list = []
+        filtered_rules = []
+
+        for rule in rules:
+            rule_hash = hash(rule)
+            if rule_hash in hash_list:
+                continue
+            hash_list.append(rule_hash)
+            filtered_rules.append(rule)
+        return filtered_rules
+
+
+
+class FirewallRule(object):
+    """Represents a single firewall rule."""
+    def __init__(self, rule):
+        self._action = rule.get("action", None)
+        self._name = rule.get("name", None)
+        self._description = rule.get("description", None)
+        self._source = rule.get("source", None)
+        self._destination = rule.get("destination", None)
+        self._application = rule.get("application", None)
+        self._direction = rule.get("direction", None)
+        self._services = self._format_services()
+        self._format_addresses()
+
+    def _format_addresses(self):
+        """Formats the source and destination ipAddress fields to allow space separated inputs"""
+        for field in (self._source, self._destination):
+            if not field:
+                continue
+
+            ip_address = field.get("ipAddress", None)
+            if not ip_address:
+                continue
+
+            if not isinstance(ip_address,list):
+                ip_address = [ip_address]
+
+            field["ipAddress"] = " ".join(ip_address).split()
+
+    
+    def _format_services(self):
+        """Formats the services block by removing duplicate rules. Formatting also adds capability for space separated src/dst port entries. Also adds certain fields (like 'any') if some parameters (like 'port')  are empty. This helps in comparing existing rules with the rule to be added"""
+        if self._application is None:
+            return None
+
+        services = self._application.get("service", None)
+        if services is None:
+            return services
+
+        if isinstance(services, dict):
+            services = [services]
+
+        for service in services:
+            if not service.get("protocol", None):
+                service["protocol"] = "TCP"
+            if not service.get("port", None):
+                service["port"] = "any"
+            if not service.get("sourcePort", None):
+                service["sourcePort"] = "any"
+
+            for field in ("port", "sourcePort"):
+                ports = service[field]
+                if not isinstance(ports, list):
+                    ports = [ports]
+
+                service[field] = " ".join(map(str,ports)).split()  
+
+        self._application["service"] = services
+
+        return services     
+ 
+    
+    
+    def _get_hashable_entity(self, field, dict_keys_to_extract=[], extractor_algorithm=None):  
+        """Given an object, extracts the part which needs to be hashed for comparison. For custom objects"""
+        if extractor_algorithm:
+            return extractor_algorithm(field)
+
+        if isinstance(field, list):
+            return ",".join(sorted(map(str,field)))
+        elif isinstance(field, (str,int,bool)):
+            return str(field)
+        elif isinstance(field, dict):
+            hash_list = []
+            for entity in dict_keys_to_extract:
+                value = field.get(entity, "")
+                hash_list.append(self._get_hashable_entity(value))
+            return "/".join(hash_list)
+        else:
+            return ""
+
+    
+    def _extract_services(self, services):
+        """Custom extractor for services block"""
+        if not services:
+            return ""
+
+        if isinstance(services, dict):
+            services = [services]
+
+        service_hash_list = []
+        for service in sorted(services):
+            service_hash_list.append(self._get_hashable_entity(service, ["protocol", "sourcePort", "port", "icmpType"]))
+                
+        return "/".join(service_hash_list)
+
+
+    def get_rule(self):
+        """Get the rule represented by this object"""
+        return { "name":self._name, "action":self._action, "description":self._description, "direction":self._direction, "source":self._source, "destination":self._destination, "application":self._application }
+
+    def __hash__(self):
+        """Get the hash of the rule represented by this object"""
+        name_hash_string = self._get_hashable_entity(self._name)
+        action_hash_string = self._get_hashable_entity(self._action)
+        description_hash_string = self._get_hashable_entity(self._description)
+
+        source_hash_string = self._get_hashable_entity(self._source, ["ipAddress","vnicGroupId","groupingObjectId"])
+        destination_hash_string = self._get_hashable_entity(self._destination, ["ipAddress","vnicGroupId","groupingObjectId"])
+        application_id_hash_string = self._get_hashable_entity(self._application, ["applicationId"])
+
+        service_hash_string = self._get_hashable_entity(self._services, extractor_algorithm=self._extract_services)
+        direction_hash_string = self._get_hashable_entity(self._direction)
+
+        hash_tuple = (name_hash_string, action_hash_string, description_hash_string, source_hash_string, destination_hash_string, application_id_hash_string, service_hash_string, direction_hash_string)
+
+        return hash(hash_tuple)
+
+    def __str__(self):
+        return str(self.get_rule())
+  
+def _to_string(obj):
+    """Recursively convert primitive objects to strings(as expected by the API)"""
+    if obj is None:
+        return obj
+
+    primitive = (int, float, str, bool)
+    if isinstance(obj, primitive):
+        return str(obj)
+
+    elif isinstance(obj, dict):
+        for k in obj:
+            obj[k] = _to_string(obj[k])
+        return obj
+
+    elif isinstance(obj, (list, tuple)):
+        obj = list(map(_to_string, obj))
+        return obj
+
+    else:
+        raise ValueError("caught unhandled object type: " + str(obj))
+
+ 
+
+def query_firewall_rules(client_session, edge_id):
+    """ Queries the edge for the list of currently existing firewall rules"""
+    resp = client_session.read("nsxEdgeFirewallConfig", uri_parameters={"edgeId": edge_id})
+    return resp["body"]["firewall"]["firewallRules"]["firewallRule"]
+
+
+def get_edge_id(client_session, edge_name):
+    """Returns the edge_id for a given edge_name"""
+    resp = client_session.read("nsxEdges")
+    edges = resp["body"]["pagedEdgeList"]["edgePage"]["edgeSummary"]
+
+    if not isinstance(edges, list):
+        edges = [edges]
+    for edge in edges:
+        if edge["name"] == edge_name:
+            return edge["id"]
+    return None
+
+
+def display_firewall_rules(rules):
+    """ Displays the firewall rules in human readable format when the 'query' mode is used"""
+    print_str = ""
+    for rule in rules:
+        print_str += "-" * 100
+
+        rule_id = rule["id"]
+        rule_name = rule.get("name", "")
+
+        print_str += "\n%-20s %-40s" % ("RULE ID", rule_id)
+        print_str += "\n%-20s %-40s" % ("RULE NAME", rule_name)
+
+        source = rule.get("source", None)
+
+        if source:
+            print_str += "\n%-20s %-40s" % ("SOURCE", source)
+        else:
+            print_str += "\n%-20s %-40s" % ("SOURCE", "ANY")
+
+        destination = rule.get("destination", None)
+        if destination:
+            print_str += "\n%-20s %-40s" % ("DESTINATION", destination)
+        else:
+            print_str += "\n%-20s %-40s" % ("DESTINATION", "ANY")
+
+        application = rule.get("application", None)
+        if application:
+            print_str += "\n%-20s %-40s" % ("APPLICATION", application)
+        else:
+            print_str += "\n%-20s %-40s" % ("APPLICATION", "ANY")
+
+        action = rule["action"]
+        print_str += "\n%-20s %-40s" % ("ACTION", action)
+
+        description = rule.get("description", "")
+        print_str += "\n%-20s %-40s" % ("DESCRIPTION", description)
+
+        print_str += "\n" + "-" * 100
+        print_str += "\n\n"
+
+    return print_str
+
+
+def main():
+    """main function:
+         Accept arguments from Ansible
+         Create an nsxramlclient session
+         Depending on the mode of operation call the specific function
+    """
+    module = AnsibleModule(argument_spec=
+    dict(
+        nsxmanager_spec=dict(required=True, type="dict"),
+        edge_name=dict(required=False),
+        edge_id=dict(required=False),
+        mode=dict(required=True, choices=["create", "append", "query", "delete", "set_default_action", "reset"]),
+        source=dict(required=False, type="dict"),
+        destination=dict(required=False, type="dict"),
+        action=dict(required=False, choices=["accept", "deny", "reject"]),
+        name=dict(required=False),
+        description=dict(required=False),
+        application=dict(required=False, type="dict"),        
+        rule_id=dict(required=False),
+        direction=dict(required=False, choices=["in", "out"]),
+        global_config=dict(required=False, type="dict"),
+        rules=dict(required=False, type="list"),
+        default_action=dict(required=False, choices=["accept", "deny", "reject"]),
+    ), required_one_of=[["edge_name", "edge_id"]])
+
+    try:
+        client_session = NsxClient(module.params['nsxmanager_spec']['raml_file'],
+                                   module.params['nsxmanager_spec']['host'],
+                                   module.params['nsxmanager_spec']['user'],
+                                   module.params['nsxmanager_spec']['password'])
+    except:
+        module.fail_json(msg="Could not connect to the NSX manager")
+
+    
+
+    edge_name = module.params.get("edge_name", None)
+    if not edge_name:
+        edge_id = module.params["edge_id"]
+    else:
+        edge_id = get_edge_id(client_session, edge_name)
+        if not edge_id:
+            module.fail_json(msg="The edge with the name %s does not exist." % (edge_name))
+
+    mode = module.params["mode"]
+    action = module.params.get("action", None)
+    name = module.params.get("name", None)
+    rule_id = module.params.get("rule_id", None)
+    application = module.params.get("application", None)
+    source = module.params.get("source", None)
+    destination = module.params.get("destination", None)
+    description = module.params.get("description", None)
+    direction = module.params.get("direction", None)
+    rules = module.params.get("rules", None)
+    global_config = module.params.get("global_config", None)
+    default_action = module.params.get("default_action", None)
+
+    if mode == "create":
+        #'create' mode:
+        #   1)Create a Firewall object out of the given rules,global_config and default_action
+        #   2)Get the resource body to be sent
+        #   3)Send the resource body to the NSX Manager
+        if not rules:
+            module.fail_json(msg="The parameter 'rules' is required in order to create the firewall rules")
+
+        firewall_rules = []
+        for rule in rules:
+            firewall_rules.append(FirewallRule(rule))
+  
+        F = Firewall(firewall_rules, global_config, default_action)
+        resource_body = F.get_resource_body()
+
+
+        resp = client_session.update("nsxEdgeFirewallConfig", uri_parameters={"edgeId": edge_id},
+                                     request_body_dict=resource_body)
+        if resp["status"] == 204:
+            module.exit_json(changed=True, msg="Successfully created the rules for the edge with ID %s" % (edge_id))
+        else:
+            module.fail_json(msg="The resource could not be created")
+
+
+    elif mode == "append":
+        #'append' mode:
+        #   1)Check if the rule to be added already exists in the firewall
+        #   2)If yes, exit
+        #   3)If no, create the resource body and send the request to the NSX Manager
+
+        if not action:
+            module.fail_json(msg="The 'action' attribute is mandatory while appending a new rule")
+
+
+        rule_to_be_added = FirewallRule({"name":name, "action":action, "description":description, "source":source, "destination":destination, "application":application, "direction":direction})
+
+        current_rules = [FirewallRule(rule) for rule in query_firewall_rules(client_session, edge_id)]
+        current_hashes = [hash(rule) for rule in current_rules]
+        if hash(rule_to_be_added) in current_hashes:
+            module.exit_json(changed=False, msg="The given rule already exists in the firewall")
+
+        resource_body = append_api_resource_body
+        resource_body["firewallRules"]["firewallRule"] = rule_to_be_added.get_rule() 
+
+        resp = client_session.create("firewallRules", uri_parameters={"edgeId": edge_id},
+                                     request_body_dict=resource_body)
+        if resp["status"] == 201:
+            module.exit_json(changed=True, meta={"ruleId": resp["objectId"]})
+        else:
+            module.fail_json(msg="The resource could not be created")
+
+    elif mode == "query":
+        #'query' mode:
+        #   1)Query the rules existing for the given edge
+        #   2)Display the results (requires <result>.split("\n") in Ansible as Ansible does not support printing newlines
+        rules = query_firewall_rules(client_session, edge_id)
+        print_str = display_firewall_rules(rules)
+
+        module.exit_json(changed=False, meta={"output": print_str})
+
+    elif mode == "delete":
+        #'delete' mode:
+        #   - Delete the rule with the given rule_id
+        if not rule_id:
+            module.fail_json(msg="The parameter 'rule_id' is required to delete a given rule")
+        resp = client_session.delete("firewallRule", uri_parameters={"ruleId": rule_id, "edgeId": edge_id})
+        if resp["status"] == 204:
+            module.exit_json(changed=True, msg="Rule with the ID %s successfully deleted" % (rule_id))
+        else:
+            module.fail_json(msg="Could not delete the rule with ID %s. Make sure that the rule exists" % (rule_id))
+
+    elif mode == "set_default_action":
+        #'set_default_action' mode:
+        #   - Sets the default action for the firewall(can be 'accept', 'deny' or 'reject')
+        if not default_action:
+            module.fail_json(msg="The parameter 'default_action' is required to set the default action")
+
+        resource_body = default_action_resource_body
+        resource_body["firewallDefaultPolicy"]["action"] = default_action
+
+        resp = client_session.update("defaultFirewallPolicy", uri_parameters={"edgeId": edge_id},
+                                     request_body_dict=resource_body)
+        if resp["status"] == 204:
+            module.exit_json(changed=True, msg="Successfully updated the firewall config")
+        else:
+            module.fail_json(msg="The resource could not be updated")
+
+    elif mode == "reset":
+        #'reset' mode:
+        #   - Resets the firewall by deleting all the existing rules
+        resp = client_session.delete("nsxEdgeFirewallConfig",  uri_parameters={"edgeId": edge_id})
+        if resp["status"] == 204:
+            module.exit_json(msg="Successfully reset the firewall configuration for the edge with ID %s" %(edge_id), changed=True)
+        else:
+            module.fail_json(msg="Could not reset the firewall rules for the edge with ID %s" %(edge_id))
+
+
+
+from ansible.module_utils.basic import *
+from nsxramlclient.client import NsxClient
+
+if __name__ == "__main__":
+    main()

--- a/library/nsx_edge_nat.py
+++ b/library/nsx_edge_nat.py
@@ -42,33 +42,13 @@ def create_nat_rule(client_session, edge_name, nat_enabled, loggingEnabled, acti
     edge_id, edge_params = get_edge(client_session, edge_name)
 
     if action == 'snat':
-        nat_rule_dict = {'action': action,
-                         'vnic': vnic,
-                         'originalAddress': originalAddress,
-                         'translatedAddress': translatedAddress,
-                         'snatMatchDestinationAddress': matchAddress,
-                         'loggingEnabled': loggingEnabled,
-                         'enabled': nat_enabled,
-                         'protocol': protocol,
-                         'originalPort': originalPort,
-                         'translatedPort': translatedPort,
-                         'snatMatchDestinationPort': matchPort
-                        }
+        nat_rule_dict = {'action': action, 'vnic': vnic, 'originalAddress': originalAddress, 'translatedAddress': translatedAddress, 'loggingEnabled': loggingEnabled, 'enabled': nat_enabled, 'protocol': protocol, 'originalPort': originalPort, 'translatedPort': translatedPort}
+
         if protocol == 'icmp':
             nat_rule_dict['icmpType'] = icmpType
     elif action == 'dnat':
-        nat_rule_dict = {'action': action,
-                         'vnic': vnic,
-                         'originalAddress': originalAddress,
-                         'translatedAddress': translatedAddress,
-                         'dnatMatchSourceAddress': matchAddress,
-                         'loggingEnabled': loggingEnabled,
-                         'enabled': nat_enabled,
-                         'protocol': protocol,
-                         'originalPort': originalPort,
-                         'translatedPort': translatedPort,
-                         'dnatMatchSourcePort': matchPort
-                        }
+        nat_rule_dict = {'action': action, 'vnic': vnic, 'originalAddress': originalAddress, 'translatedAddress': translatedAddress, 'loggingEnabled': loggingEnabled, 'enabled': nat_enabled, 'protocol': protocol, 'originalPort': originalPort, 'translatedPort': translatedPort}
+
         if protocol == 'icmp':
             nat_rule_dict['icmpType'] = icmpType
 
@@ -86,8 +66,8 @@ def main():
                 nsxmanager_spec=dict(required=True, no_log=True, type='dict'),
                 name=dict(required=True),
                 mode=dict(required=True, choices=['create', 'delete']),
-                nat_enabled=dict(default=True),
-                loggingEnabled=dict(default=False),
+                nat_enabled=dict(default='true'),
+                loggingEnabled=dict(default='false'),
                 rule_type=dict(required=True, choices=['dnat', 'snat']),
                 vnic=dict(),
                 originalAddress=dict(default='any'),
@@ -124,7 +104,7 @@ def main():
                                      )
         if module.params['rule_type'] == 'dnat':
             changed = create_nat_rule(client_session, module.params['name'], module.params['nat_enabled'],
-                                      module.params['logginEnabled'], module.params['rule_type'], module.params['vnic'],
+                                      module.params['loggingEnabled'], module.params['rule_type'], module.params['vnic'],
                                       module.params['originalAddress'], module.params['translatedAddress'],
                                       module.params['dnatMatchSourceAddress'], module.params['protocol'],
                                       module.params['icmpType'], module.params['originalPort'], module.params['translatedPort'],

--- a/library/nsx_edge_nat.py
+++ b/library/nsx_edge_nat.py
@@ -22,7 +22,59 @@ def get_edge(client_session, edge_name):
     return edge_id, edge_params
 
 
-def create_nat_rule(client_session, esg_id, rule_type, vnic, protocol, source_ip, source_port, dest_port, ip_addr, port_range):
+def create_nat_rule(client_session, edge_name, nat_enabled, loggingEnabled, action, vnic, originalAddress, translatedAddress,
+                    dnatMatchSourceAddress, snatMatchAddress, protocol, icmpType, originalPort,
+                    translatedPort, dnatMatchSourcePort, snatMatchDestinationPort):
+    """
+    :param enabled: Enable rule. Boolean. Default is true.
+    :param loggingEnabled: Enable logging. Default is false.
+    :param action: Type of NAT. Values can be 'snat' or 'dnat'
+    :param vnic: Interface on which the translation is applied.
+    :param originalAddress: Original address or range. Default is 'any'
+    :param translatedAddress: Translated address or range. Default is 'any'.
+    :param dnatMatchSourceAddress: Source address to match in DNAT rules. Default is 'any'.
+    :param snatMatchDestinationAddress: Destination address to match in SNAT address. Default is 'any'.
+    :param protocol: Protocol. Default is 'any'.
+    :param icmpType: ICMP type. Only supported when protocol == 'icmp'. Default is 'any'.
+    ;param originalPort: Source port for SNAT, destination port for DNAT. Default is 'any'.
+    :param translatedPort: Translated port. Default is 'any'.
+    :param dnatMatchSourcePort: Source port in DNAT rules. Not valid in SNAT rules. Default is 'any'.
+    :param snatMatchDestinationPort: Destination port in SNAT rules. Not valid in DNAT fules. Default is 'any'.
+    """
+    edge_id, edge_params = get_edge(client_session, edge_name)
+
+    if action == 'snat':
+        nat_rule_dict = {'enabled': nat_enabled,
+                         'loggingEnabled': loggingEnabled,
+                         'action': action,
+                         'vnic': vnic,
+                         'originalAddress': originalAddress,
+                         'translatedAddress': translatedAddress,
+                         'snatMatchDestinationAddress': snatMatchDestinationAddress,
+                         'protocol': protocol,
+                         'originalPort': originalPort,
+                         'translatedPort': translatedPort,
+                         'snatMatchDestinationPort': snatMatchDestinationPort
+                        }
+        if protocol == 'icmp':
+            nat_rule_dict['icmpType'] = icmpType
+    elif action == 'dnat':
+        nat_rule_dict = {'enabled': nat_enabled,
+                         'loggingEnabled': loggingEnabled,
+                         'action': action,
+                         'vnic': vnic,
+                         'originalAddress': originalAddress,
+                         'translatedAddress': translatedAddress,
+                         'dnatMatchSourceAddress': dnatMatchSourceAddress,
+                         'protocol': protocol,
+                         'originalPort': originalPort,
+                         'translatedPort': translatedPort,
+                         'dnatMatchSourcePort': dnatMatchSourcePort
+                        }
+        if protocol == 'icmp':
+            nat_rule_dict['icmpType'] = icmpType
+
+    cfg_result = client_session.create('nat', uri_parameters={'edgeId': edge_id}, request_body_dict={'natRule': nat_rule_dict})
 
     if cfg_result['status'] == 204:
         return True
@@ -34,15 +86,21 @@ def main():
             argument_spec=dict(
                 state=dict(default='present', choices=['present', 'absent']),
                 nsxmanager_spec=dict(required=True, no_log=True, type='dict'),
-                name=dict(required=True),
+                edge_name=dict(required=True),
+                nat_enabled=dict(default=True),
+                loggingEnabled=dict(default=False),
+                action=dict(required=True, choices=['dnat', 'snat']),
                 vnic=dict(),
-                protocol=dict(default='any'),
-                source_ip=dict(required=True),
-                source_port=dict(default='any'),
-                dest_port=dict(default='any'),
-                ip_addr=dict(required=True),
-                port_range=dict(),
-                rule_type=dict(required=True, choices=['dnat', 'snat'])
+                originalAddress=dict(default='any'),
+                translatedAddress=dict(default='any'),
+                dnatMatchSourceAddress=dict(default='any'),
+                snatMatchDestinationAddress=dict(default='any'),
+                procotol=dict(default='any'),
+                icmpType=dict(default='any'),
+                originalPort=dict(default='any'),
+                translatedPort=dict(default='any'),
+                dnatMatchSourcePort=dict(default='any'),
+                snatMatchDestinationPort=dict(default='any')
             ),
             supports_check_mode=False
     )

--- a/library/nsx_edge_nat.py
+++ b/library/nsx_edge_nat.py
@@ -42,17 +42,17 @@ def create_nat_rule(client_session, edge_name, nat_enabled, loggingEnabled, acti
     edge_id, edge_params = get_edge(client_session, edge_name)
 
     if action == 'snat':
-        nat_rule_dict = {'action': action, 'vnic': vnic, 'originalAddress': originalAddress, 'translatedAddress': translatedAddress, 'loggingEnabled': loggingEnabled, 'enabled': nat_enabled, 'protocol': protocol, 'originalPort': originalPort, 'translatedPort': translatedPort, 'snatMatchDestinationAddress': 'any', 'snatMatchDestinationPort': 'any'}
+        nat_rule_dict = { 'natRule': {'action': action, 'vnic': vnic, 'originalAddress': originalAddress, 'translatedAddress': translatedAddress, 'loggingEnabled': loggingEnabled, 'enabled': nat_enabled, 'protocol': protocol, 'originalPort': originalPort, 'translatedPort': translatedPort, 'snatMatchDestinationAddress': 'any', 'snatMatchDestinationPort': 'any'}}
 
         if protocol == 'icmp':
             nat_rule_dict['icmpType'] = icmpType
     elif action == 'dnat':
-        nat_rule_dict = {'action': action, 'vnic': vnic, 'originalAddress': originalAddress, 'translatedAddress': translatedAddress, 'loggingEnabled': loggingEnabled, 'enabled': nat_enabled, 'protocol': protocol, 'originalPort': originalPort, 'translatedPort': translatedPort, 'dnatMatchSourceAddress': 'any', 'dnatMatchSourcePort': 'any'}
+        nat_rule_dict = { 'natRule': {'action': action, 'vnic': vnic, 'originalAddress': originalAddress, 'translatedAddress': translatedAddress, 'loggingEnabled': loggingEnabled, 'enabled': nat_enabled, 'protocol': protocol, 'originalPort': originalPort, 'translatedPort': translatedPort, 'dnatMatchSourceAddress': 'any', 'dnatMatchSourcePort': 'any'}}
 
         if protocol == 'icmp':
             nat_rule_dict['icmpType'] = icmpType
 
-    cfg_result = client_session.create('edgeNatRules', uri_parameters={'edgeId': edge_id}, request_body_dict={'natRule': nat_rule_dict})
+    cfg_result = client_session.create('edgeNatRules', uri_parameters={'edgeId': edge_id}, request_body_dict={'natRules': nat_rule_dict})
 
     if cfg_result['status'] == 204:
         return True

--- a/library/nsx_edge_nat.py
+++ b/library/nsx_edge_nat.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+__author__ = 'virtualelephant'
+
+# From the vmware/nsxansible/nsx_edge_router.py Ansible library
+def get_edge(client_session, edge_name):
+    """
+    :param client session: An instance of an NsxClient Session
+    :param edge_name: The name of the edge searched
+    :return: A tuple, with the first item being the edge or dlr id as string of the first Scope found with the
+             right name and the second item being a dictionary of the logical parameters as return by the NSX API
+    """
+    all_edge = client_session.read_all_pages('nsxEdges', 'read')
+
+    try:
+        edge_params = [scope for scope in all_edge if scope['name'] == edge_name][0]
+        edge_id = edge_params['objectId']
+    except IndexError:
+        return None, None
+
+    return edge_id, edge_params
+
+
+def create_nat_rule(client_session, esg_id, rule_type, vnic, protocol, source_ip, source_port, dest_port, ip_addr, port_range):
+
+    if cfg_result['status'] == 204:
+        return True
+    else:
+        return False
+
+def main():
+    module = AnsibleModule(
+            argument_spec=dict(
+                state=dict(default='present', choices=['present', 'absent']),
+                nsxmanager_spec=dict(required=True, no_log=True, type='dict'),
+                name=dict(required=True),
+                vnic=dict(),
+                protocol=dict(default='any'),
+                source_ip=dict(required=True),
+                source_port=dict(default='any'),
+                dest_port=dict(default='any'),
+                ip_addr=dict(required=True),
+                port_range=dict(),
+                rule_type=dict(required=True, choices=['dnat', 'snat'])
+            ),
+            supports_check_mode=False
+    )
+
+    from nsxramlclient.client import NsxClient
+    client_session = NsxClient(module.params['nsxmanager_spec']['raml_file'],
+                               module.params['nsxmanager_spec']['host'],
+                               module.params['nsxmanager_spec']['user'],
+                               module.params['nsxmanager_spec']['password'])
+
+    changed = False
+    edge_id, edge_params = get_edge(client_session, module.params['name'])
+    
+    if changed:
+        module.exit_json(changed=True)
+    else:
+        module.exit_json(changed=False)
+
+
+from ansible.module_utils.basic import *
+if __name__ == '__main__':
+    main()

--- a/library/nsx_edge_nat.py
+++ b/library/nsx_edge_nat.py
@@ -42,12 +42,12 @@ def create_nat_rule(client_session, edge_name, nat_enabled, loggingEnabled, acti
     edge_id, edge_params = get_edge(client_session, edge_name)
 
     if action == 'snat':
-        nat_rule_dict = { 'natRule': {'action': action, 'vnic': vnic, 'originalAddress': originalAddress, 'translatedAddress': translatedAddress, 'loggingEnabled': loggingEnabled, 'enabled': nat_enabled, 'protocol': protocol, 'originalPort': originalPort, 'translatedPort': translatedPort, 'snatMatchDestinationAddress': 'any', 'snatMatchDestinationPort': 'any'}}
+        nat_rule_dict = { 'natRule': {'action': action, 'vnic': vnic, 'originalAddress': originalAddress, 'translatedAddress': translatedAddress, 'loggingEnabled': loggingEnabled, 'enabled': nat_enabled, 'protocol': protocol, 'originalPort': originalPort, 'translatedPort': translatedPort, 'snatMatchDestinationAddress': matchAddress, 'snatMatchDestinationPort': matchPort}}
 
         if protocol == 'icmp':
             nat_rule_dict['icmpType'] = icmpType
     elif action == 'dnat':
-        nat_rule_dict = { 'natRule': {'action': action, 'vnic': vnic, 'originalAddress': originalAddress, 'translatedAddress': translatedAddress, 'loggingEnabled': loggingEnabled, 'enabled': nat_enabled, 'protocol': protocol, 'originalPort': originalPort, 'translatedPort': translatedPort, 'dnatMatchSourceAddress': 'any', 'dnatMatchSourcePort': 'any'}}
+        nat_rule_dict = { 'natRule': {'action': action, 'vnic': vnic, 'originalAddress': originalAddress, 'translatedAddress': translatedAddress, 'loggingEnabled': loggingEnabled, 'enabled': nat_enabled, 'protocol': protocol, 'originalPort': originalPort, 'translatedPort': translatedPort, 'dnatMatchSourceAddress': matchAddress, 'dnatMatchSourcePort': matchPort}}
 
         if protocol == 'icmp':
             nat_rule_dict['icmpType'] = icmpType

--- a/library/nsx_edge_nat.py
+++ b/library/nsx_edge_nat.py
@@ -42,12 +42,12 @@ def create_nat_rule(client_session, edge_name, nat_enabled, loggingEnabled, acti
     edge_id, edge_params = get_edge(client_session, edge_name)
 
     if action == 'snat':
-        nat_rule_dict = {'action': action, 'vnic': vnic, 'originalAddress': originalAddress, 'translatedAddress': translatedAddress, 'loggingEnabled': loggingEnabled, 'enabled': nat_enabled, 'protocol': protocol, 'originalPort': originalPort, 'translatedPort': translatedPort}
+        nat_rule_dict = {'action': action, 'vnic': vnic, 'originalAddress': originalAddress, 'translatedAddress': translatedAddress, 'loggingEnabled': loggingEnabled, 'enabled': nat_enabled, 'protocol': protocol, 'originalPort': originalPort, 'translatedPort': translatedPort, 'snatMatchDestinationAddress': 'any', 'snatMatchDestinationPort': 'any'}
 
         if protocol == 'icmp':
             nat_rule_dict['icmpType'] = icmpType
     elif action == 'dnat':
-        nat_rule_dict = {'action': action, 'vnic': vnic, 'originalAddress': originalAddress, 'translatedAddress': translatedAddress, 'loggingEnabled': loggingEnabled, 'enabled': nat_enabled, 'protocol': protocol, 'originalPort': originalPort, 'translatedPort': translatedPort}
+        nat_rule_dict = {'action': action, 'vnic': vnic, 'originalAddress': originalAddress, 'translatedAddress': translatedAddress, 'loggingEnabled': loggingEnabled, 'enabled': nat_enabled, 'protocol': protocol, 'originalPort': originalPort, 'translatedPort': translatedPort, 'dnatMatchSourceAddress': 'any', 'dnatMatchSourcePort': 'any'}
 
         if protocol == 'icmp':
             nat_rule_dict['icmpType'] = icmpType

--- a/library/nsx_edge_router.py
+++ b/library/nsx_edge_router.py
@@ -385,6 +385,7 @@ def main():
             interfaces=dict(required=True, type='dict'),
             default_gateway=dict(),
             default_gateway_adminDistance=dict(default='1'),
+            default_gateway_vnic=dict(),
             routes=dict(default=[], type='list'),
             username=dict(),
             password=dict(),

--- a/library/nsx_edge_router.py
+++ b/library/nsx_edge_router.py
@@ -147,19 +147,15 @@ def get_esg_routes(client_session, esg_id):
     return routes, dfgw, dfgw_adminDistance
 
 
-def config_def_gw(client_session, esg_id, dfgw, dfgw_adminDistance=None, vnic, mtu=None):
+def config_def_gw(client_session, esg_id, dfgw, vnic, mtu, dfgw_adminDistance):
     if not mtu:
-	mtu = '1500'
-    if not dfgw_adminDistance:
-	dfgw_adminDistance = '1'
-
+        mtu = '1500'
     rtg_cfg = client_session.read('routingConfigStatic', uri_parameters={'edgeId': esg_id})['body']
     if dfgw:
         try:
 	    rtg_cfg['staticRouting']['defaultRoute'] = {'gatewayAddress': dfgw, 'vnic': vnic, 'mtu': mtu, 'adminDistance': dfgw_adminDistance}
         except KeyError:
-            rtg_cfg['staticRouting']['defaultRoute'] = {'gatewayAddress': dfgw, 'adminDistance': dfgw_adminDistance,
-                                                        'mtu': '1500'}
+            rtg_cfg['staticRouting']['defaultRoute'] = {'gatewayAddress': dfgw, 'vnic': vnic, 'adminDistance': dfgw_adminDistance, 'mtu': mtu}
     else:
         rtg_cfg['staticRouting']['defaultRoute'] = None
 
@@ -386,6 +382,7 @@ def main():
             default_gateway=dict(),
             default_gateway_adminDistance=dict(default='1'),
             default_gateway_vnic=dict(),
+            mtu=dict(),
             routes=dict(default=[], type='list'),
             username=dict(),
             password=dict(),
@@ -423,7 +420,7 @@ def main():
             module.exit_json(changed=False, esg_create_response=esg_create_response,
                              esg_delete_response=esg_delete_response)
 
-    routes, current_dfgw, current_dfgw_adminDistance, current_dfgw_vnic = get_esg_routes(client_session, edge_id)
+    routes, current_dfgw, current_dfgw_adminDistance = get_esg_routes(client_session, edge_id)
     fw_state = get_firewall_state(client_session, edge_id)
     ifaces_changed = check_interfaces(client_session, edge_id, module)
     routes_changed = check_routes(client_session, edge_id, routes, module)
@@ -435,10 +432,8 @@ def main():
 
     if module.params['default_gateway']:
         if current_dfgw != (module.params['default_gateway']) or \
-                (current_dfgw_adminDistance != module.params['default_gateway_adminDistance']) or \
-		(current_dfgw_vnic != module.params['default_gateway_vnic']):
-            changed = config_def_gw(client_session, edge_id, module.params['default_gateway'],
-                                    module.params['default_gateway_adminDistance'], module.params['default_gateway_vnic'])
+                (current_dfgw_adminDistance != module.params['default_gateway_adminDistance']):
+            changed = config_def_gw(client_session, edge_id, module.params['default_gateway'], module.params['default_gateway_vnic'], module.params['mtu'], module.params['default_gateway_adminDistance'])
     else:
         if current_dfgw:
             changed = config_def_gw(client_session, edge_id, None, None)

--- a/library/vcenter_gather_moids.py
+++ b/library/vcenter_gather_moids.py
@@ -38,6 +38,8 @@ def get_mo(content, searchedname, vim_type_list):
     for object in mo:
         if object.name == searchedname:
             return object
+	elif re.search( searchedname, object.name ):
+            return object
     return None
 
 def main():
@@ -84,8 +86,9 @@ def main():
             module.fail_json(msg='Could not find {} in vCenter'.format(module.params[searched_parameter]))
 
     object_id = object_mo._moId
+    object_name = object_mo.name
 
-    module.exit_json(changed=False, object_id=object_id, datacenter_moid=datacenter_moid)
+    module.exit_json(changed=False, object_id=object_id, object_name=object_name, datacenter_moid=datacenter_moid)
 
 from ansible.module_utils.basic import *
 from ansible.module_utils.vmware import *

--- a/readme.md
+++ b/readme.md
@@ -862,8 +862,6 @@ Example:
 ### Module `nsx_edge_dhcp`
 #### Creates a DHCP scope in an Edge Services Gateway
 
-### Module `nsx_dlr`
-##### Deploys, updates or deletes a Distributed Logical Router (DLR) in NSX
 - name:
 Mandatory: name of the ESG to be modified
 - ip_range:
@@ -905,6 +903,9 @@ Example:
       next_server: '{{ tftp_server }}'
       bootfile: '{{ bootfile }}'
 ```
+
+### Module `nsx_dlr`
+##### Deploys, updates or deletes a Distributed Logical Router (DLR) in NSX
 
 - name:
 Mandatory: name of the DLR to be deployed

--- a/readme.md
+++ b/readme.md
@@ -859,8 +859,52 @@ Example:
       ruleId: '196622'
 ```
 
+### Module `nsx_edge_dhcp`
+#### Creates a DHCP scope in an Edge Services Gateway
+
 ### Module `nsx_dlr`
 ##### Deploys, updates or deletes a Distributed Logical Router (DLR) in NSX
+- name:
+Mandatory: name of the ESG to be modified
+- ip_range:
+Optional: An IP range for the IP pool
+- default_gateway:
+Optional: The default gateway for the IP pool
+- subnet:
+Optional: The subnet of the IP pool
+- domain_name:
+Optional: The DNS domain name
+- dns_server_1:
+Optional: The primary DNS for the IP pool
+- dns_server_2:
+Optional: The secondary DNS for the IP pool
+- lease_time:
+Optional: The DHCP lease time value, default is 1 day
+- auto_dns:
+Optional: If set to true, the DNS servers from the NSX Manager will be used
+- next_server:
+Optional: Global TFTP server setting
+- bootfile:
+Optional: File to be downloaded from the TFTP server (option 67)
+
+Example:
+```yml
+  tasks:
+  - name: Create DHCP pool on NSX Edge
+    nsx_edge_dhcp:
+      nsxmanager_spec: "{{ nsxmanager_spec }}"
+      name: '{{ edge_name }}'
+      mode: 'create_pool'
+      ip_range: '{{ ip_range }}'
+      subnet: '{{ netmask }}'
+      default_gateway: '{{ gateway }}'
+      domain_name: '{{ domain }}'
+      dns_server_1: '{{ dns1_ip }}'
+      dns_server_2: '{{ dns2_ip }}'
+      lease_time: '{{ lease_time }}'
+      next_server: '{{ tftp_server }}'
+      bootfile: '{{ bootfile }}'
+```
 
 - name:
 Mandatory: name of the DLR to be deployed

--- a/readme.md
+++ b/readme.md
@@ -770,6 +770,79 @@ routes:
   - {network: '10.11.14.0/24', next_hop: '192.168.178.2'}
 ```
 
+### Module `nsx_edge_nat`
+##### Deploys or deletes a NAT rule in an Edge Service Gateway
+
+- name:
+Mandatory: name of the Edge Services Gateway to be modified
+- mode:
+Mandatory: create or delete
+- state:
+Optional: present or absent, defaults to present
+- nat_enabled:
+Optional: true or false, defaults to true
+- loggingEnabled: 
+Optional: true or false, defaults to false
+- rule_type:
+Optional: type of NAT rule to create. dnat or snat.
+- description:
+Optional: A user-defined description for the rule
+- vnic:
+Optional: Interface on which the translation is applied
+- originalAddress:
+Optional: Original address or range, default is 'any'
+- translatedAddress:
+Optional: Translated address or range, default is 'any'
+- matchAddress:
+Optional: Either dnatMatchSourceAddress or snatMatchSourceAddress, default is 'any'
+- protocol:
+Optional: Network protocol, default is 'any'
+- icmpType:
+Optional: ICMP type. Only supported when protocol == 'icmp'. Default is 'any'
+- originalPort:
+Optional: Source port for SNAT, destination port for DNAT. Default is 'any'
+- translatedPort:
+Optional: Translated port. Default is 'any'
+- matchPort:
+Optional: Used for either dnatMatchSourcePort or snatMatchDestinationPort. Default is 'any'
+- ruleTag:
+Optional: This can be used to specify user-controlled ruleId. Must be between 65537-131072
+- description:
+Optional: User-defined description field.
+
+Example:
+```yml
+  tasks:
+  - name: Create SSH Bastion host DNAT rule
+    nsx_edge_nat:
+      nsxmanager_spec: '{{ nsxmanager_spec }}'
+      mode: 'create'
+      name: '{{ edge_name }}'
+      description: 'Ansible created inbound SSH'
+      loggingEnabled: 'true'
+      rule_type: 'dnat'
+      vnic: '0'
+      protocol: 'tcp'
+      originalAddress: '10.180.138.131'
+      originalPort: '22'
+      translatedAddress: '192.168.0.2'
+      translatedPort: '22'
+
+  - name: Create default outbound SNAT rule
+    nsx_edge_nat:
+      nsxmanager_spec: '{{ nsxmanager_spec }}'
+      mode: 'create'
+      name: '{{ edge_name }}'
+      description: 'Ansible created default outbound'
+      loggingEnabled: 'true'
+      rule_type: 'snat'
+      vnic: '0'
+      protocol: 'any'
+      originalAddress: '192.168.0.0/20'
+      originalPort: 'any'
+      translatedAddress: '10.180.138.131'
+      translatedPort: 'any'
+```
 
 ### Module `nsx_dlr`
 ##### Deploys, updates or deletes a Distributed Logical Router (DLR) in NSX

--- a/readme.md
+++ b/readme.md
@@ -810,6 +810,8 @@ Optional: This can be used to specify user-controlled ruleId. Must be between 65
 - description:
 Optional: User-defined description field.
 
+##### Create NAT rule
+
 Example:
 ```yml
   tasks:
@@ -842,6 +844,19 @@ Example:
       originalPort: 'any'
       translatedAddress: '10.180.138.131'
       translatedPort: 'any'
+```
+
+##### Delete NAT rule
+
+Example:
+```yml
+  tasks:
+  - name: Delete HTTP DNAT rule
+    nsx_edge_nat:
+      nsxmanager_spec: '{{ nsxmanager_spec }}'
+      mode: 'delete'
+      name: '{{ edge_name }}'
+      ruleId: '196622'
 ```
 
 ### Module `nsx_dlr`

--- a/test_edge_nat.yml
+++ b/test_edge_nat.yml
@@ -11,6 +11,8 @@
       nsxmanager_spec: '{{ nsxmanager_spec }}'
       mode: 'create'
       name: '{{ edge_name }}'
+      description: 'Ansible created DNAT rule'
+      loggingEnabled: 'true'
       rule_type: 'dnat'
       vnic: '0'
       protocol: 'tcp'
@@ -24,6 +26,8 @@
       nsxmanager_spec: '{{ nsxmanager_spec }}'
       mode: 'create'
       name: '{{ edge_name }}'
+      description: 'Ansible created SNAT rule'
+      loggingEnabled: 'true'
       rule_type: 'snat'
       vnic: '0'
       protocol: 'any'
@@ -31,3 +35,10 @@
       originalPort: 'any'
       translatedAddress: '10.0.0.1'
       translatedPort: 'any'
+
+  - name: Delete NAT rule
+    nsx_edge_nat:
+      nsxmanager_spec: '{{ nsxmanager_spec }}'
+      mode: 'delete'
+      name: '{{ edge_name }}'
+      ruleId: '192622'

--- a/test_edge_nat.yml
+++ b/test_edge_nat.yml
@@ -1,0 +1,33 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: False
+  vars_files:
+    - nsxanswer.yml
+
+  tasks:
+  - name: Create SSH DNAT rule
+    nsx_edge_nat:
+      nsxmanager_spec: '{{ nsxmanager_spec }}'
+      mode: 'create'
+      name: '{{ edge_name }}'
+      rule_type: 'dnat'
+      vnic: '0'
+      protocol: 'tcp'
+      originalAddress: '10.0.0.1'
+      originalPort: '22'
+      translatedAddress: '192.168.0.2'
+      translatedPort: '22'
+
+  - name: Create default outbound SNAT rule
+    nsx_edge_nat:
+      nsxmanager_spec: '{{ nsxmanager_spec }}'
+      mode: 'create'
+      name: '{{ edge_name }}'
+      rule_type: 'snat'
+      vnic: '0'
+      protocol: 'any'
+      originalAddress: '192.168.0.0/20'
+      originalPort: 'any'
+      translatedAddress: '10.0.0.1'
+      translatedPort: 'any'

--- a/test_portgroup.yml
+++ b/test_portgroup.yml
@@ -1,0 +1,17 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: False
+  vars_files:
+    - nsxanswer.yml
+
+  tasks:
+  - name: Gather MOID for NSX Logical Switch Portgroup
+    vcenter_gather_moids:
+      hostname: "{{ vcenter }}"
+      username: "{{ vcenter_user }}"
+      password: "{{ vcenter_pass }}"
+      datacenter_name: "{{ dc }}"
+      portgroup_name: "{{ switch_name }}"
+      validate_certs: False
+    register: gather_moids_switch 


### PR DESCRIPTION
**nsx_edge_router.py**
**Summary**: Extends the module to be able to specify the MTU and vNIC for the default route creation code.

**vcenter_gather_moids.py**
**Summary**: Adds a regex search for to the object.name, and also adds the object.name to the returned values. This allows an Ansible playbook to create a new NSX Logical Switch, based on a name, and then determine the distributed port group vSphere created and use that to attach a VM to the new network.