### PR TITLE
Check role before changing

### DIFF
--- a/library/nsx_manager_roles.py
+++ b/library/nsx_manager_roles.py
@@ -116,17 +116,13 @@ def main():
     user_role = get_user_role(client_session, module.params['name'])
 
     if user_role:
-        if module.params['state'] == 'present':
+        if module.params['state'] == 'present' or module.params['state'] == 'update':
             if module.params['role_type'] != user_role['body']['accessControlEntry']['role']:
                 changed = update_user_role(client_session, module.params['name'], module.params['role_type'])
-        elif module.params['state'] == 'update':
-            changed = update_user_role(client_session, module.params['name'], module.params['role_type'])        
         elif module.params['state'] == 'absent':
             changed = delete_user_role(client_session, module.params['name'])
     else:
-        if module.params['state'] == 'present':
-            changed = create_user_role(client_session, module.params['name'], module.params['role_type'], module.params['is_group'])
-        elif module.params['state'] == 'update':
+        if module.params['state'] == 'present' or module.params['state'] == 'update':
             changed = create_user_role(client_session, module.params['name'], module.params['role_type'], module.params['is_group'])
 
     module.exit_json(changed=changed)

--- a/library/nsx_manager_roles.py
+++ b/library/nsx_manager_roles.py
@@ -35,12 +35,12 @@ def get_user_role(client_session, user_id):
     :param user_id: The userId. To specify a domain user, use user@domain not domain\user
     """
 
-    try:
-        cfg_result = client_session.read('userRoleMgmt', uri_parameters={'userId': user_id})
-    except:
-        cfg_result = False
+    cfg_result = client_session.read('userRoleMgmt', uri_parameters={'userId': user_id})
 
-    return cfg_result
+    if cfg_result['status'] == 200:
+        return cfg_result
+
+    return False
 
 def update_user_role(client_session, user_id, role_type):
     """
@@ -108,7 +108,8 @@ def main():
     client_session = NsxClient(module.params['nsxmanager_spec']['raml_file'],
                                module.params['nsxmanager_spec']['host'],
                                module.params['nsxmanager_spec']['user'],
-                               module.params['nsxmanager_spec']['password'])
+                               module.params['nsxmanager_spec']['password'],
+                               fail_mode="continue")
 
     changed = False
 


### PR DESCRIPTION
Fixes #86 

Uses 'fail_mode="continue"' in NsxClient instantiation to stop it from failing when a non 2xx status is returned from NSX.

Added a true/false return to the getter method that is then used to determine if a change is actually required.

Added logic to only make changes if necessary.